### PR TITLE
Update missing report types

### DIFF
--- a/build/specifications/ReportGenerator.json
+++ b/build/specifications/ReportGenerator.json
@@ -87,9 +87,12 @@
       "name": "ReportTypes",
       "values": [
         "Badges",
+        "Cobertura",
         "CsvSummary",
         "Html",
         "HtmlInline",
+        "HtmlInline_AzurePipelines",
+        "HtmlInline_AzurePipelines_Dark",
         "HtmlChart",
         "HtmlSummary",
         "Latex",
@@ -98,7 +101,8 @@
         "PngChart",
         "TextSummary",
         "Xml",
-        "XmlSummary"
+        "XmlSummary",        
+        "SonarQube"        
       ]
     },
     {


### PR DESCRIPTION
https://github.com/danielpalme/ReportGenerator

HtmlInline_AzurePipelines, HtmlInline_AzurePipelines_Dark, SonarQube

 Report types:       The output formats and scope (separated by semicolon).
                       Values: Badges, Cobertura, CsvSummary, Html, HtmlChart, HtmlInline,
                       HtmlInline_AzurePipelines, HtmlInline_AzurePipelines_Dark,
                       HtmlSummary, Latex, LatexSummary, MHtml, PngChart, SonarQube, TextSummary, Xml, XmlSummary