### PR TITLE
Framework ordering to allow nuke to build on VS for Mac

### DIFF
--- a/source/Nuke.CodeGeneration/Nuke.CodeGeneration.csproj
+++ b/source/Nuke.CodeGeneration/Nuke.CodeGeneration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>

--- a/source/Nuke.Common.Tests/Nuke.Common.Tests.csproj
+++ b/source/Nuke.Common.Tests/Nuke.Common.Tests.csproj
@@ -6,6 +6,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Nuke.Common\Nuke.Common.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   
 </Project>

--- a/source/Nuke.Common/Nuke.Common.csproj
+++ b/source/Nuke.Common/Nuke.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>

--- a/source/Nuke.GlobalTool.Tests/Nuke.GlobalTool.Tests.csproj
+++ b/source/Nuke.GlobalTool.Tests/Nuke.GlobalTool.Tests.csproj
@@ -7,6 +7,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Nuke.Common\Nuke.Common.csproj" />
     <ProjectReference Include="..\Nuke.GlobalTool\Nuke.GlobalTool.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
VS for Mac dumbly selects the first framework it finds and builds it - successfully - net461

but then nuke.common.tests cannot find a netstandard2.0 version of nuke.common, and the build fails.

ordering the target frameworks allows VS for Mac to successfully build the netcore/netststandard project targets