### PR TITLE
Search for GitVersion in transitive dependencies

### DIFF
--- a/source/Nuke.Common/Tools/GitVersion/GitVersionTasks.cs
+++ b/source/Nuke.Common/Tools/GitVersion/GitVersionTasks.cs
@@ -42,7 +42,7 @@ namespace Nuke.Common.Tools.GitVersion
                               "GitVersion.CommandLine.DotNetCore",
                               "GitVersion.CommandLine"
                           }
-                .Select(x => NuGetPackageResolver.TryGetLocalInstalledPackage(x, ToolPathResolver.NuGetPackagesConfigFile))
+                .Select(x => NuGetPackageResolver.TryGetLocalInstalledPackage(x, ToolPathResolver.NuGetPackagesConfigFile, includeDependencies: true))
                 .WhereNotNull()
                 .FirstOrDefault().NotNull("package != null");
             return Directory.GetFiles(package.Directory, "GitVersion.*", SearchOption.AllDirectories)


### PR DESCRIPTION
I have a use-case where projects depend on a private package which then depends on Nuke and the GitVersion. So I think it's useful to add reference only to the internal package and then look into transitive dependencies if there is GitVersion.
If there is any drawback (well, other than speed) let me know!