### PR TITLE
Remove setting of NUGET_XMLDOC_MODE=skip environment variable in build scripts

### DIFF
--- a/source/Nuke.GlobalTool/templates/build.netcore.ps1
+++ b/source/Nuke.GlobalTool/templates/build.netcore.ps1
@@ -22,7 +22,6 @@ $DotNetChannel = "Current"
 
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
 $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
-$env:NUGET_XMLDOC_MODE = "skip"
 
 ###########################################################################
 # EXECUTION

--- a/source/Nuke.GlobalTool/templates/build.netcore.sh
+++ b/source/Nuke.GlobalTool/templates/build.netcore.sh
@@ -18,7 +18,6 @@ DOTNET_CHANNEL="Current"
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-export NUGET_XMLDOC_MODE="skip"
 
 ###########################################################################
 # EXECUTION


### PR DESCRIPTION
When NUGET_XMLDOC_MODE=skip is set, the NuGet package restore does not extract Xml comments from NuGet packages. While this might save disk space, it prevents features that rely on the presence of these comment files. For example. generated Swagger REST API definitions rely on these Xml comments.

I've got two use cases where I rely on Xml comments to be present:
1. Using shared packages in web projects which generate API documentation endpoints using Swagger / Open API. The missing Xml comments result in my API docs not including comments and descriptions for models from shared packages.
2. In one of my projects, I extract Xml comments from a shared package. This works fine locally when using Visual Studio to restore packages, but the build fails on the server due to the missing Xml comments.

I think when setting defaults, NUKE should always try to not include surprising behavior. It took me quite a bit to track down what caused the failures in my projects, since I wasn't expecting the build script to change the behavior of the package restoration.