### PR TITLE
Unity tool ToolPath changes

### DIFF
--- a/source/Nuke.Common/Tools/Unity/UnityBaseSettings.cs
+++ b/source/Nuke.Common/Tools/Unity/UnityBaseSettings.cs
@@ -10,13 +10,11 @@ namespace Nuke.Common.Tools.Unity
 {
     public partial class UnityBaseSettings
     {
-        public override string ToolPath { get; internal set; } = UnityTasks.GetToolPath();
-        
         public override Action<OutputType, string> CustomLogger => UnityTasks.UnityLogger;
 
         public string GetToolPath()
         {
-            return ToolPath;
+            return UnityTasks.GetToolPath();
         }
 
         public string GetLogFile()

--- a/source/Nuke.Common/Tools/Unity/UnityBaseSettings.cs
+++ b/source/Nuke.Common/Tools/Unity/UnityBaseSettings.cs
@@ -10,11 +10,13 @@ namespace Nuke.Common.Tools.Unity
 {
     public partial class UnityBaseSettings
     {
+        public override string ToolPath { get; internal set; } = UnityTasks.GetToolPath();
+        
         public override Action<OutputType, string> CustomLogger => UnityTasks.UnityLogger;
 
         public string GetToolPath()
         {
-            return UnityTasks.GetToolPath();
+            return ToolPath;
         }
 
         public string GetLogFile()

--- a/source/Nuke.Common/Tools/Unity/UnityTasks.cs
+++ b/source/Nuke.Common/Tools/Unity/UnityTasks.cs
@@ -26,11 +26,19 @@ namespace Nuke.Common.Tools.Unity
 
         public static string GetToolPath()
         {
-            return EnvironmentInfo.IsWin
-                ? EnvironmentInfo.SpecialFolder(SpecialFolders.ProgramFiles) + "/Editor/Unity.exe"
-                : EnvironmentInfo.IsOsx
-                    ? "/Applications/Unity/Unity.app/Contents/MacOS/Unity"
-                    : null;
+            const string unityWinPath = @"\Unity\Editor\Unity.exe";
+            if (EnvironmentInfo.IsWin)
+            {
+                if (EnvironmentInfo.Is32Bit) return EnvironmentInfo.SpecialFolder(SpecialFolders.ProgramFilesX86) + unityWinPath;
+                if (EnvironmentInfo.Is64Bit) return EnvironmentInfo.SpecialFolder(SpecialFolders.ProgramFiles) + unityWinPath;
+            }
+
+            if (EnvironmentInfo.IsOsx)
+            {
+                return "/Applications/Unity/Unity.app/Contents/MacOS/Unity";
+            }
+
+            return null;
         }
 
         private static void PreProcess<T>(ref T unitySettings)


### PR DESCRIPTION
Updated UnityTasks.GetToolPath to find default Windows x86/x64 installation paths.