### PR TITLE
Add GitVersion.VersionSourceSha property

### DIFF
--- a/build/specifications/GitVersion.json
+++ b/build/specifications/GitVersion.json
@@ -261,6 +261,10 @@
           "type": "string"
         },
         {
+          "name": "VersionSourceSha",
+          "type": "string"
+        },
+        {
           "name": "CommitsSinceVersionSource",
           "type": "string"
         },

--- a/source/Nuke.Common/Tools/GitVersion/GitVersion.Generated.cs
+++ b/source/Nuke.Common/Tools/GitVersion/GitVersion.Generated.cs
@@ -1,5 +1,5 @@
-// Generated from https://github.com/nuke-build/common/blob/master/build/specifications/GitVersion.json
-// Generated with Nuke.CodeGeneration version LOCAL (OSX,.NETStandard,Version=v2.0)
+// Generated from https://github.com/hayhay27/common/blob/master/build/specifications/GitVersion.json
+// Generated with Nuke.CodeGeneration version LOCAL (Windows,.NETStandard,Version=v2.0)
 
 using JetBrains.Annotations;
 using Newtonsoft.Json;
@@ -299,6 +299,7 @@ namespace Nuke.Common.Tools.GitVersion
         public virtual string NuGetVersion { get; internal set; }
         public virtual string NuGetPreReleaseTagV2 { get; internal set; }
         public virtual string NuGetPreReleaseTag { get; internal set; }
+        public virtual string VersionSourceSha { get; internal set; }
         public virtual string CommitsSinceVersionSource { get; internal set; }
         public virtual string CommitsSinceVersionSourcePadded { get; internal set; }
         public virtual string CommitDate { get; internal set; }


### PR DESCRIPTION
This change relates to [this commit](https://github.com/GitTools/GitVersion/commit/debc1fc10689047edf94c9fc7f1ef47f8776a0cf)
VersionSourceSha appeared in version 5.0.0-beta2-26 of [GitVersion.CommandLine.DotNetCore](https://www.nuget.org/packages/GitVersion.CommandLine.DotNetCore/5.0.0-beta2-26)