### PR TITLE
Add missing report type for report generator: TeamCity summary

### DIFF
--- a/build/specifications/ReportGenerator.json
+++ b/build/specifications/ReportGenerator.json
@@ -102,7 +102,8 @@
         "TextSummary",
         "Xml",
         "XmlSummary",
-        "SonarQube"
+        "SonarQube",
+        "TeamCitySummary"
       ]
     },
     {


### PR DESCRIPTION
As documented under: https://github.com/danielpalme/ReportGenerator

Do you regenerate yourself or should I do that within my PR?