### PR TITLE
Parameter help text should include additional information

### DIFF
--- a/source/Nuke.Common.Tests/Execution/HelpTextServiceTest.cs
+++ b/source/Nuke.Common.Tests/Execution/HelpTextServiceTest.cs
@@ -19,8 +19,10 @@ namespace Nuke.Common.Tests.Execution {
         private void ParameterHelpText(NukeBuild build, string expectedParamName, string expectedHelpText) {
 
             var helpTextLine = HelpTextService.GetParametersText(build).Split(Environment.NewLine + "  --").FirstOrDefault(q => q.StartsWith(expectedParamName));
-            if (!string.IsNullOrEmpty(helpTextLine))
-                helpTextLine = helpTextLine.Split(" ", 2)[1].Replace(Environment.NewLine, " ").Trim();
+            if (!string.IsNullOrEmpty(helpTextLine) && helpTextLine.Contains(" ")) {
+                helpTextLine = helpTextLine.Split(" ", 2)[1];
+                helpTextLine = string.Join(" ", helpTextLine.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Select(q => q.Trim()));
+            }
             helpTextLine.Should().EndWith(expectedHelpText);
         }
 

--- a/source/Nuke.Common.Tests/Execution/HelpTextServiceTest.cs
+++ b/source/Nuke.Common.Tests/Execution/HelpTextServiceTest.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using System.Linq;
 
 namespace Nuke.Common.Tests.Execution {
+#pragma warning disable IDE0051 // Remove unused private members
     public class HelpTextServiceTest {
 
         private class DummyBuild : NukeBuild {
@@ -44,7 +45,7 @@ namespace Nuke.Common.Tests.Execution {
 
         [Fact]
         public void StringParamWithDefaultValue() {
-            ParameterHelpText(new StringParamWithDefaultValueBuild(), "string-param", "The Default Value is \"TEST\".");
+            ParameterHelpText(new StringParamWithDefaultValueBuild(), "string-param", "The default value is \"TEST\".");
         }
 
         private class EnumParamWithDefaultValueBuild : DummyBuild {
@@ -55,8 +56,29 @@ namespace Nuke.Common.Tests.Execution {
 
         [Fact]
         public void EnumParamWithDefaultValue() {
-            ParameterHelpText(new EnumParamWithDefaultValueBuild(), "enum-param", "The available Values are \"Yes\", \"No\", \"Maybe\". The Default Value is \"Maybe\".");
+            ParameterHelpText(new EnumParamWithDefaultValueBuild(), "enum-param", "The available values are \"Yes\", \"No\", \"Maybe\". The default value is \"Maybe\".");
+        }
+
+        private class IntArrayWithSeparatorBuild : DummyBuild {
+            [Parameter(Separator = ",")]
+            private readonly int[] IntArrayParam;
+        }
+
+        [Fact]
+        public void IntArrayWithDefaultValues() {
+            ParameterHelpText(new IntArrayWithSeparatorBuild(), "int-array-param", "List of Int32 values, separated by \",\".");
+        }
+
+        private class StringArrayWithDefaultValueBuild : DummyBuild {
+            [Parameter()]
+            private readonly string[] StrArrayParam = new string[] { "Elem1", "Elem2" };
+        }
+
+        [Fact]
+        public void StringArrayWithSeparatorAndDefaultValue() {
+            ParameterHelpText(new StringArrayWithDefaultValueBuild(), "str-array-param", "List of String values, separated by \" \". The default value is [\"Elem1\", \"Elem2\"].");
         }
 
     }
+#pragma warning restore IDE0051 // Remove unused private members
 }

--- a/source/Nuke.Common.Tests/Execution/HelpTextServiceTest.cs
+++ b/source/Nuke.Common.Tests/Execution/HelpTextServiceTest.cs
@@ -1,0 +1,53 @@
+﻿using Nuke.Common.Execution;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using FluentAssertions;
+
+namespace Nuke.Common.Tests.Execution {
+    public class HelpTextServiceTest {
+
+        private class DummyBuild : NukeBuild {
+
+            public DummyBuild() {
+                ExecutableTargets = new[] { new ExecutableTarget { Name = "Dummy" } };
+            }
+        }
+
+        private class StringParamWithDescriptionBuild : DummyBuild {
+            [Parameter("TestDescription")]
+            private readonly string TestParam;
+        }
+
+        private class StringParamWithDefaultValueBuild : DummyBuild {
+            [Parameter()]
+            private readonly string StringParam = "TEST";
+        }
+
+        private class EnumParamWithDefaultValueBuild : DummyBuild {
+            public enum TestEnum { Yes, No, Maybe }
+            [Parameter()]
+            private readonly TestEnum EnumParam = TestEnum.Maybe;
+        }
+
+
+        public static IEnumerable<object[]> Data =>
+                new List<object[]>
+                    {
+                        new object[] { new StringParamWithDescriptionBuild(),  "  --test-param         TestDescription." },
+                        new object[] { new StringParamWithDefaultValueBuild(), "  --string-param       The Default Value is \"TEST\"." },
+                        new object[] { new EnumParamWithDefaultValueBuild(),   "  --enum-param         The available Values are \"Yes\", \"No\", \"Maybe\". The Default Value is \"Maybe\"." },
+                    };
+
+        [Theory]
+        [MemberData(nameof(Data))]
+        public void ParameterHelpText(NukeBuild build, string expectedHelpText) {
+
+            HelpTextService.GetParametersText(build).
+                Split(Environment.NewLine).
+                Should().Contain(expectedHelpText);
+        }
+
+    }
+}

--- a/source/Nuke.Common.Tests/Execution/HelpTextServiceTest.cs
+++ b/source/Nuke.Common.Tests/Execution/HelpTextServiceTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using Xunit;
 using FluentAssertions;
+using System.Linq;
 
 namespace Nuke.Common.Tests.Execution {
     public class HelpTextServiceTest {
@@ -15,14 +16,33 @@ namespace Nuke.Common.Tests.Execution {
             }
         }
 
+        private void ParameterHelpText(NukeBuild build, string expectedParamName, string expectedHelpText) {
+
+            var helpTextLine = HelpTextService.GetParametersText(build).Split(Environment.NewLine + "  --").FirstOrDefault(q => q.StartsWith(expectedParamName));
+            if (!string.IsNullOrEmpty(helpTextLine))
+                helpTextLine = helpTextLine.Split(" ", 2)[1].Replace(Environment.NewLine, " ").Trim();
+            helpTextLine.Should().EndWith(expectedHelpText);
+        }
+
+
         private class StringParamWithDescriptionBuild : DummyBuild {
             [Parameter("TestDescription")]
             private readonly string TestParam;
         }
 
+        [Fact]
+        public void StringParamWithDescription() {
+            ParameterHelpText(new StringParamWithDescriptionBuild(), "test-param", "TestDescription.");
+        }
+
         private class StringParamWithDefaultValueBuild : DummyBuild {
             [Parameter()]
             private readonly string StringParam = "TEST";
+        }
+
+        [Fact]
+        public void StringParamWithDefaultValue() {
+            ParameterHelpText(new StringParamWithDefaultValueBuild(), "string-param", "The Default Value is \"TEST\".");
         }
 
         private class EnumParamWithDefaultValueBuild : DummyBuild {
@@ -31,22 +51,9 @@ namespace Nuke.Common.Tests.Execution {
             private readonly TestEnum EnumParam = TestEnum.Maybe;
         }
 
-
-        public static IEnumerable<object[]> Data =>
-                new List<object[]>
-                    {
-                        new object[] { new StringParamWithDescriptionBuild(),  "  --test-param         TestDescription." },
-                        new object[] { new StringParamWithDefaultValueBuild(), "  --string-param       The Default Value is \"TEST\"." },
-                        new object[] { new EnumParamWithDefaultValueBuild(),   "  --enum-param         The available Values are \"Yes\", \"No\", \"Maybe\". The Default Value is \"Maybe\"." },
-                    };
-
-        [Theory]
-        [MemberData(nameof(Data))]
-        public void ParameterHelpText(NukeBuild build, string expectedHelpText) {
-
-            HelpTextService.GetParametersText(build).
-                Split(Environment.NewLine).
-                Should().Contain(expectedHelpText);
+        [Fact]
+        public void EnumParamWithDefaultValue() {
+            ParameterHelpText(new EnumParamWithDefaultValueBuild(), "enum-param", "The available Values are \"Yes\", \"No\", \"Maybe\". The Default Value is \"Maybe\".");
         }
 
     }

--- a/source/Nuke.Common/Execution/HelpTextService.cs
+++ b/source/Nuke.Common/Execution/HelpTextService.cs
@@ -47,14 +47,15 @@ namespace Nuke.Common.Execution
 
             void PrintParameter(MemberInfo parameter)
             {
-                var description = SplitLines(
-                    // TODO: remove
-                    ParameterService.Instance.GetParameterDescription(parameter)
-                        ?.Replace("{default_target}", defaultTarget?.Name).Append(".")
-                    ?? "<no description>");
+                // TODO: remove
+                var description = ParameterService.Instance.GetParameterDescription(parameter)
+                        ?.Replace("{default_target}", defaultTarget?.Name)
+                        ?? ParameterService.Instance.GetParameterGeneratedDescription(parameter, build);
+                
+                var descriptionLines = SplitLines(description?.Append(".") ?? "<no description>");
                 var parameterName = ParameterService.Instance.GetParameterName(parameter).SplitCamelHumpsWithSeparator("-");
-                builder.AppendLine($"  --{parameterName.PadRight(padRightParameter)}  {description.First()}");
-                foreach (var line in description.Skip(count: 1))
+                builder.AppendLine($"  --{parameterName.PadRight(padRightParameter)}  {descriptionLines.First()}");
+                foreach (var line in descriptionLines.Skip(count: 1))
                     builder.AppendLine($"{new string(c: ' ', count: padRightParameter + 6)}{line}");
             }
 

--- a/source/Nuke.Common/Execution/ParameterService.cs
+++ b/source/Nuke.Common/Execution/ParameterService.cs
@@ -52,6 +52,22 @@ namespace Nuke.Common.Execution
         }
 
         [CanBeNull]
+        public string GetParameterGeneratedDescription(MemberInfo member, NukeBuild build) 
+        {
+            var description = new List<string>();
+
+            var parameterType = (member as FieldInfo)?.FieldType ?? (member as PropertyInfo)?.PropertyType ?? null;
+            if (parameterType?.IsEnum == true)
+                description.Add($"The available Values are {string.Join(", ", Enum.GetNames(parameterType).Select(q => $"\"{q}\""))}");
+
+            var defaultValue = member.GetValue(build);
+            if (defaultValue != null)
+                description.Add($"The Default Value is \"{defaultValue}\"");
+
+            return description.Count > 0 ? string.Join(". ", description) : null;
+        }
+
+        [CanBeNull]
         public IEnumerable<(string Text, object Object)> GetParameterValueSet(MemberInfo member, object instance)
         {
             var attribute = member.GetCustomAttribute<ParameterAttribute>();


### PR DESCRIPTION
Hi... I gave [this issue](https://github.com/nuke-build/nuke/issues/27) a try and added an implementation. 
I added the GetParameterGeneratedDescription Method to the ParameterService and used this method in the PrintParameter Method, when the parameter description is null. 

I also added unit tests for the following cases:

[Parameter("TestDescription")] string TestParam
  => TestDescription.
[Parameter()] string StringParam = "TEST"
  => The default value is "TEST".
[Parameter()] TestEnum EnumParam = TestEnum.Maybe
  => The available values are "Yes", "No", "Maybe". The default value is "Maybe".
[Parameter(Separator = ",")] int[] IntArrayParam
  => List of Int32 values, separated by ",".
[Parameter()] string[] StrArrayParam = new string[] { "Elem1", "Elem2" };
  => List of String values, separated by " ". The default value is ["Elem1", "Elem2"].