### PR TITLE
Fix TeamServices BuildNumber to use string

### DIFF
--- a/source/Nuke.Common/BuildServers/TeamServices.cs
+++ b/source/Nuke.Common/BuildServers/TeamServices.cs
@@ -1,4 +1,4 @@
-// Copyright 2019 Maintainers of NUKE.
+﻿// Copyright 2019 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -40,7 +40,7 @@ namespace Nuke.Common.BuildServers
         public string AgentWorkFolder => Variable("AGENT_WORKFOLDER");
         public string ArtifactStagingDirectory => Variable("BUILD_ARTIFACTSTAGINGDIRECTORY");
         public long BuildId => Variable<long>("BUILD_BUILDID");
-        public long BuildNumber => Variable<long>("BUILD_BUILDNUMBER");
+        public string BuildNumber => Variable<string>("BUILD_BUILDNUMBER");
         public string BuildUri => Variable("BUILD_BUILDURI");
         public string BinariesDirectory => Variable("BUILD_BINARIESDIRECTORY");
         public string DefinitionName => Variable("BUILD_DEFINITIONNAME");


### PR DESCRIPTION
Resolves: https://github.com/nuke-build/nuke/issues/279