### PR TITLE
Update NuGet.Packaging to v4.9.2

### DIFF
--- a/source/Nuke.Common/Nuke.Common.csproj
+++ b/source/Nuke.Common/Nuke.Common.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
-    <PackageReference Include="NuGet.Packaging" Version="4.5.0" />
+    <PackageReference Include="NuGet.Packaging" Version="4.9.2" />
     <PackageReference Include="Refit" Version="4.0.0" />
     <PackageReference Include="SharpZipLib" Version="1.1.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />


### PR DESCRIPTION
Fixes https://github.com/nuke-build/nuke/issues/280

I was able to isolate the cause of the problem to the reference to NuGet.Packaging. Updating the reference to at least v4.9.2 fixes the problem. 
Didn't checked the exact changes between the versions so I don't know what the problem exactly is.