### PR TITLE
Fix: Prompting required parameters for skipped targets

### DIFF
--- a/source/Nuke.Common/Execution/BuildExecutor.cs
+++ b/source/Nuke.Common/Execution/BuildExecutor.cs
@@ -25,11 +25,13 @@ namespace Nuke.Common.Execution
 
         public static void Execute(NukeBuild build, [CanBeNull] IReadOnlyCollection<string> skippedTargets)
         {
+            MarkSkippedTargets(build, skippedTargets);
+            
+            RequirementService.ValidateRequirements(build);
+            
             var invocationHash = GetInvocationHash();
             var previouslyExecutedTargets = GetPreviouslyExecutedTargets(invocationHash);
             File.WriteAllLines(BuildAttemptFile, new[] { invocationHash });
-
-            MarkSkippedTargets(build, skippedTargets);
 
             BuildManager.CancellationHandler += ExecuteAssuredTargets;
 
@@ -135,6 +137,7 @@ namespace Nuke.Common.Execution
                 .Where(x => x.HasSkippingCondition(x.StaticConditions))
                 .ForEach(MarkTargetSkipped);
         }
+        
 
         private static string GetInvocationHash()
         {

--- a/source/Nuke.Common/Execution/BuildExecutor.cs
+++ b/source/Nuke.Common/Execution/BuildExecutor.cs
@@ -60,7 +60,7 @@ namespace Nuke.Common.Execution
         {
             if (target.Status == ExecutionStatus.Skipped ||
                 previouslyExecutedTargets.Contains(target.Name) ||
-                target.HasSkippingCondition(target.DynamicConditions))
+                HasSkippingCondition(target, target.DynamicConditions))
             {
                 target.Status = ExecutionStatus.Skipped;
                 build.OnTargetSkipped(target.Name);
@@ -134,10 +134,32 @@ namespace Nuke.Common.Execution
             }
 
             build.ExecutionPlan
-                .Where(x => x.HasSkippingCondition(x.StaticConditions))
+                .Where(x => HasSkippingCondition(x, x.StaticConditions))
                 .ForEach(MarkTargetSkipped);
         }
         
+        private static bool HasSkippingCondition(ExecutableTarget target, IEnumerable<Expression<Func<bool>>> conditions)
+        {
+            // TODO: trim outer parenthesis
+            string GetSkipReason(Expression<Func<bool>> condition) =>
+                condition.Body.ToString()
+                    .Replace("False", "false")
+                    .Replace("True", "true")
+                    .Replace("OrElse", "||")
+                    .Replace("AndAlso", "&&")
+                    // TODO: should get actual build type name
+                    .Replace("value(Build).", string.Empty);
+
+            target.SkipReason = null; // solely for testing
+
+            foreach (var condition in conditions)
+            {
+                if (!condition.Compile().Invoke())
+                    target.SkipReason = GetSkipReason(condition);
+            }
+
+            return target.SkipReason != null;
+        }
 
         private static string GetInvocationHash()
         {

--- a/source/Nuke.Common/Execution/BuildManager.cs
+++ b/source/Nuke.Common/Execution/BuildManager.cs
@@ -69,7 +69,6 @@ namespace Nuke.Common.Execution
                 CancellationHandler += Finish;
 
                 InjectionUtility.InjectValues(build, x => !x.IsFast);
-                RequirementService.ValidateRequirements(build);
 
                 build.OnBuildInitialized();
 

--- a/source/Nuke.Common/Execution/ExecutableTarget.cs
+++ b/source/Nuke.Common/Execution/ExecutableTarget.cs
@@ -44,28 +44,5 @@ namespace Nuke.Common.Execution
         public TimeSpan Duration { get; internal set; }
         public bool Invoked { get; internal set; }
         public string SkipReason { get; internal set; }
-        
-        internal bool HasSkippingCondition(IEnumerable<Expression<Func<bool>>> conditions)
-        {
-            // TODO: trim outer parenthesis
-            string GetSkipReason(Expression<Func<bool>> condition) =>
-                condition.Body.ToString()
-                    .Replace("False", "false")
-                    .Replace("True", "true")
-                    .Replace("OrElse", "||")
-                    .Replace("AndAlso", "&&")
-                    // TODO: should get actual build type name
-                    .Replace("value(Build).", string.Empty);
-
-            SkipReason = null; // solely for testing
-
-            foreach (var condition in conditions)
-            {
-                if (!condition.Compile().Invoke())
-                    SkipReason = GetSkipReason(condition);
-            }
-
-            return SkipReason != null;
-        }
     }
 }

--- a/source/Nuke.Common/Execution/ExecutableTarget.cs
+++ b/source/Nuke.Common/Execution/ExecutableTarget.cs
@@ -44,5 +44,28 @@ namespace Nuke.Common.Execution
         public TimeSpan Duration { get; internal set; }
         public bool Invoked { get; internal set; }
         public string SkipReason { get; internal set; }
+        
+        internal bool HasSkippingCondition(IEnumerable<Expression<Func<bool>>> conditions)
+        {
+            // TODO: trim outer parenthesis
+            string GetSkipReason(Expression<Func<bool>> condition) =>
+                condition.Body.ToString()
+                    .Replace("False", "false")
+                    .Replace("True", "true")
+                    .Replace("OrElse", "||")
+                    .Replace("AndAlso", "&&")
+                    // TODO: should get actual build type name
+                    .Replace("value(Build).", string.Empty);
+
+            SkipReason = null; // solely for testing
+
+            foreach (var condition in conditions)
+            {
+                if (!condition.Compile().Invoke())
+                    SkipReason = GetSkipReason(condition);
+            }
+
+            return SkipReason != null;
+        }
     }
 }

--- a/source/Nuke.Common/Execution/RequirementService.cs
+++ b/source/Nuke.Common/Execution/RequirementService.cs
@@ -17,7 +17,7 @@ namespace Nuke.Common.Execution
     {
         public static void ValidateRequirements(NukeBuild build)
         {
-            foreach (var target in build.ExecutionPlan.Where(x => !x.HasSkippingCondition(x.StaticConditions)))
+            foreach (var target in build.ExecutionPlan.Where(x => x.Status != ExecutionStatus.Skipped))
             foreach (var requirement in target.Requirements)
             {
                 if (requirement is Expression<Func<bool>> boolExpression)

--- a/source/Nuke.Common/Execution/RequirementService.cs
+++ b/source/Nuke.Common/Execution/RequirementService.cs
@@ -17,7 +17,7 @@ namespace Nuke.Common.Execution
     {
         public static void ValidateRequirements(NukeBuild build)
         {
-            foreach (var target in build.ExecutionPlan)
+            foreach (var target in build.ExecutionPlan.Where(x => !x.HasSkippingCondition(x.StaticConditions)))
             foreach (var requirement in target.Requirements)
             {
                 if (requirement is Expression<Func<bool>> boolExpression)


### PR DESCRIPTION
Fix issue with parameters being required even when the targets that declare them as required are skipped