### PR TITLE
Bug fix TeamCity SetParameter

### DIFF
--- a/source/Nuke.Common/BuildServers/TeamCity.cs
+++ b/source/Nuke.Common/BuildServers/TeamCity.cs
@@ -146,9 +146,19 @@ namespace Nuke.Common.BuildServers
             Write("buildNumber", number);
         }
 
-        public void SetParameter(string key, string value)
+        public void SetConfigurationParameter(string name, string value)
         {
-            Write("setParameter", x => x.AddKeyValue(key, value));
+            Write("setParameter", x => x.AddKeyValue("name", name).AddKeyValue("value", value));
+        }
+
+        public void SetEnvironmentVariable(string name, string value)
+        {
+            Write("setParameter", x => x.AddKeyValue("name", $"env.{name}").AddKeyValue("value", value));
+        }
+
+        public void SetSystemProperty(string name, string value)
+        {
+            Write("setParameter", x => x.AddKeyValue("name", $"system.{name}").AddKeyValue("value", value));
         }
 
         public void AddStatisticValue(string key, string value)


### PR DESCRIPTION
Should output `##teamcity[setParameter name='ddd' value='fff']` but outputs `##teamcity[setParameter ddd='fff']`

Dokumentation: https://www.jetbrains.com/help/teamcity/build-script-interaction-with-teamcity.html#BuildScriptInteractionwithTeamCity-AddingorChangingaBuildParameter