### PR TITLE
Feature/teamcity test integration

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -141,7 +141,8 @@ partial class Build : NukeBuild
             DotNetTest(s => s
                 .SetConfiguration(Configuration)
                 .EnableNoBuild()
-                .SetVerbosity(DotNetVerbosity.Normal)
+                .ResetVerbosity()
+                .SetArgumentConfigurator(args => args.Add("--verbosity").Add("normal"))
                 .CombineWith(
                     Solution.GetProjects("*.Tests"), (cs, v) => cs
                         .SetProjectFile(v)));

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -141,8 +141,6 @@ partial class Build : NukeBuild
             DotNetTest(s => s
                 .SetConfiguration(Configuration)
                 .EnableNoBuild()
-                .SetLogger("trx")
-                .SetResultsDirectory(OutputDirectory)
                 .CombineWith(
                     Solution.GetProjects("*.Tests"), (cs, v) => cs
                         .SetProjectFile(v)));

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -141,6 +141,7 @@ partial class Build : NukeBuild
             DotNetTest(s => s
                 .SetConfiguration(Configuration)
                 .EnableNoBuild()
+                .SetVerbosity(DotNetVerbosity.Normal)
                 .CombineWith(
                     Solution.GetProjects("*.Tests"), (cs, v) => cs
                         .SetProjectFile(v)));

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -45,7 +45,6 @@
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
     <PackageReference Include="FluentAssertions" Version="5.9.0"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0"/>
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15"/>
     <PackageReference Include="xunit" Version="2.4.1"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
   </ItemGroup>

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -45,6 +45,7 @@
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
     <PackageReference Include="FluentAssertions" Version="5.9.0"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0"/>
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15"/>
     <PackageReference Include="xunit" Version="2.4.1"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
   </ItemGroup>


### PR DESCRIPTION
It is not needed to add reference `TeamCity.VSTest.TestAdapter` for this case because dotnet core xunit generates TeamCity service messages by itself.
Values for `dotnet test` verbosity level are case sensitive so you should use `normal` instead `Normal` and etc., see [this page](https://docs.microsoft.com/ru-ru/dotnet/core/tools/dotnet-test?tabs=netcore21) for details.
The minimum verbosity level for vstest reporting is `normal`.