### PR TITLE
Add basic support for Atlassian Bamboo

### DIFF
--- a/source/Nuke.Common/CI/Bamboo/Bamboo.cs
+++ b/source/Nuke.Common/CI/Bamboo/Bamboo.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2019 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+
+namespace Nuke.Common.CI.Bamboo
+{
+    /// <summary>
+    /// Interface according to the <a href="https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html">official website</a>.
+    /// </summary>
+    [PublicAPI]
+    [BuildServer]
+    [ExcludeFromCodeCoverage]
+    public class Bamboo
+    {
+        private static Lazy<Bamboo> s_instance = new Lazy<Bamboo>(() => new Bamboo());
+
+        public static Bamboo Instance => NukeBuild.Host == HostType.Bamboo ? s_instance.Value : null;
+
+        internal static bool IsRunningBamboo => Environment.GetEnvironmentVariable("BAMBOO_SERVER") != null;
+
+        internal Bamboo()
+        {
+        }
+
+        public long AgentId => EnvironmentInfo.GetVariable<long>("bamboo_agentId");
+        public string AgentWorkingDirectory => EnvironmentInfo.GetVariable<string>("bamboo_agentWorkingDirectory");
+        public string AgentHome => EnvironmentInfo.GetVariable<string>("BAMBOO_AGENT_HOME");
+        public string BuildKey => EnvironmentInfo.GetVariable<string>("bamboo_buildKey");
+        public long BuildNumber => EnvironmentInfo.GetVariable<long>("bamboo_buildNumber");
+        public string BuildPlanName => EnvironmentInfo.GetVariable<string>("bamboo_buildPlanName");
+        public string BuildResultsKey => EnvironmentInfo.GetVariable<string>("bamboo_buildResultKey");
+        public string BuildResultsUrl => EnvironmentInfo.GetVariable<string>("bamboo_buildResultsUrl");
+        public DateTime BuildTimeStamp => DateTime.Parse(EnvironmentInfo.GetVariable<string>("bamboo_buildTimeStamp"));
+        public string BuildWorkingDirectory => EnvironmentInfo.GetVariable<string>("bamboo_build_working_directory");
+        public bool BuildFailed => EnvironmentInfo.GetVariable<bool>("bamboo_buildFailed");
+        public string PlanKey => EnvironmentInfo.GetVariable<string>("bamboo_planKey");
+        public string ShortPlanKey => EnvironmentInfo.GetVariable<string>("bamboo_shortPlanKey");
+        public string PlanName => EnvironmentInfo.GetVariable<string>("bamboo_planName");
+        public string ShortPlanName => EnvironmentInfo.GetVariable<string>("bamboo_shortPlanName");
+        public string PlanStorageTag => EnvironmentInfo.GetVariable<string>("bamboo_plan_storageTag");
+        public string PlanResultsUrl => EnvironmentInfo.GetVariable<string>("bamboo_resultsUrl");
+        public string ShortJobKey => EnvironmentInfo.GetVariable<string>("bamboo_shortJobKey");
+        public string ShortJobName => EnvironmentInfo.GetVariable<string>("bamboo_shortJobName");
+    }
+}

--- a/source/Nuke.Common/HostType.cs
+++ b/source/Nuke.Common/HostType.cs
@@ -12,6 +12,7 @@ namespace Nuke.Common
         Console,
         TeamCity,
         AzurePipelines,
+        Bamboo,
         Bitrise,
         AppVeyor,
         Jenkins,

--- a/source/Nuke.Common/NukeBuild.Statics.cs
+++ b/source/Nuke.Common/NukeBuild.Statics.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Nuke.Common.CI.AppVeyor;
 using Nuke.Common.CI.AzurePipelines;
+using Nuke.Common.CI.Bamboo;
 using Nuke.Common.CI.Bitrise;
 using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.CI.GitLab;
@@ -150,6 +151,8 @@ namespace Nuke.Common
                 return HostType.Jenkins;
             if (TeamCity.IsRunningTeamCity)
                 return HostType.TeamCity;
+            if (Bamboo.IsRunningBamboo)
+                return HostType.Bamboo;
             if (AzurePipelines.IsRunningAzurePipelines)
                 return HostType.AzurePipelines;
             if (Bitrise.IsRunningBitrise)


### PR DESCRIPTION
Hello Matt,

Thank you so much for making this build system. It's the best! :)

I had some issues with builds running in Bamboo, mainly running the correct `Configuration` (`Release` in Bamboo) and using the `IsServerBuild` variable.

I then checked and noticed that **Atlassian Bamboo** is not supported, so I implemented that. I paid attention to follow the code conventions from the other CI servers. Hopefully I didn't miss anything.

**Do you think I can make any other improvements to this pull request or can we merge it as is?**

PS. Bamboo can't have any log formatting (info, error, etc) and the Console Host logging makes it show those escape sequences. I'm not sure how to make it just log normal text... just `Console.WriteLine`? Should I also write a new `OutputSink`?

Best regards,
Igor Popov