### PR TITLE
Fix SolutionSerializer to fall back to ProjectConfiguration section

### DIFF
--- a/source/Nuke.Common/ProjectModel/SolutionSerializer.cs
+++ b/source/Nuke.Common/ProjectModel/SolutionSerializer.cs
@@ -1,4 +1,4 @@
-// Copyright 2019 Maintainers of NUKE.
+﻿// Copyright 2019 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -91,8 +91,8 @@ namespace Nuke.Common.ProjectModel
             var projectRegex = new Regex(
                 $@"^Project\(""{GuidPattern("typeId")}""\)\s*=\s*{TextPattern("name")},\s*{TextPattern("path")},\s*""{GuidPattern("projectId")}""$");
 
-            var configurations = content
-                .GetGlobalSection("ProjectConfigurationPlatforms").NotNull()
+            var configurations = (content.GetGlobalSection("ProjectConfigurationPlatforms") ??
+                                  content.GetGlobalSection("ProjectConfiguration")).NotNull()
                 .Select(x => new
                              {
                                  ProjectId = Guid.Parse(x.Key.Substring(startIndex: 1, length: 36)),


### PR DESCRIPTION
`SolutionSerializer` now supports older files where project
configuration section was named "ProjectConfiguration"
instead of "ProjectConfigurationPlatforms" which is the
currently used name.  Also handles the case where no such
section is found, by treating it as no configuration
sections being available.

Fixes nuke-build/nuke#261