### PR TITLE
Added custom logger for MSBuild.

### DIFF
--- a/build/specifications/MSBuild.json
+++ b/build/specifications/MSBuild.json
@@ -7,6 +7,7 @@
   "officialUrl": "https://msdn.microsoft.com/en-us/library/ms164311.aspx",
   "help": "The Microsoft Build Engine is a platform for building applications. This engine, which is also known as MSBuild, provides an XML schema for a project file that controls how the build platform processes and builds software. Visual Studio uses MSBuild, but it doesn't depend on Visual Studio. By invoking msbuild.exe on your project or solution file, you can orchestrate and build products in environments where Visual Studio isn't installed. Visual Studio uses MSBuild to load and build managed projects. The project files in Visual Studio (.csproj,.vbproj, vcxproj, and others) contain MSBuild XML code that executes when you build a project by using the IDE. Visual Studio projects import all the necessary settings and build processes to do typical development work, but you can extend or modify them from within Visual Studio or by using an XML editor.",
   "customExecutable": true,
+  "customLogger": true,
   "tasks": [
     {
       "settingsClass": {

--- a/source/Nuke.Common/Tools/MSBuild/MSBuild.Generated.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuild.Generated.cs
@@ -1,4 +1,4 @@
-// Generated from https://github.com/nuke-build/common/blob/master/build/specifications/MSBuild.json
+﻿// Generated from https://github.com/nuke-build/common/blob/master/build/specifications/MSBuild.json
 // Generated with Nuke.CodeGeneration version LOCAL (OSX,.NETStandard,Version=v2.0)
 
 using JetBrains.Annotations;
@@ -33,7 +33,7 @@ namespace Nuke.Common.Tools.MSBuild
         public static string MSBuildPath =>
             ToolPathResolver.TryGetEnvironmentExecutable("MSBUILD_EXE") ??
             GetToolPath();
-        public static Action<OutputType, string> MSBuildLogger { get; set; } = ProcessTasks.DefaultLogger;
+        public static Action<OutputType, string> MSBuildLogger { get; set; } = CustomLogger;
         /// <summary>
         ///   <p>The Microsoft Build Engine is a platform for building applications. This engine, which is also known as MSBuild, provides an XML schema for a project file that controls how the build platform processes and builds software. Visual Studio uses MSBuild, but it doesn't depend on Visual Studio. By invoking msbuild.exe on your project or solution file, you can orchestrate and build products in environments where Visual Studio isn't installed. Visual Studio uses MSBuild to load and build managed projects. The project files in Visual Studio (.csproj,.vbproj, vcxproj, and others) contain MSBuild XML code that executes when you build a project by using the IDE. Visual Studio projects import all the necessary settings and build processes to do typical development work, but you can extend or modify them from within Visual Studio or by using an XML editor.</p>
         ///   <p>For more details, visit the <a href="https://msdn.microsoft.com/en-us/library/ms164311.aspx">official website</a>.</p>

--- a/source/Nuke.Common/Tools/MSBuild/MSBuildTasks.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuildTasks.cs
@@ -107,9 +107,9 @@ namespace Nuke.Common.Tools.MSBuild
 
         internal static void CustomLogger(OutputType type, string output)
         {
-            if (type == OutputType.Err || output.Contains(": error"))
+            if (type == OutputType.Err || output.IndexOf(": error", StringComparison.Ordinal) != -1)
                 Logger.Error(output);
-            else if (output.Contains(": warning"))
+            else if (output.IndexOf(": warning", StringComparison.Ordinal) != -1)
                 Logger.Warn(output);
             else
                 Logger.Normal(output);

--- a/source/Nuke.Common/Tools/MSBuild/MSBuildTasks.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuildTasks.cs
@@ -1,4 +1,4 @@
-// Copyright 2019 Maintainers of NUKE.
+﻿// Copyright 2019 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -104,5 +104,17 @@ namespace Nuke.Common.Tools.MSBuild
 
             return lookup;
         }
+
+        internal static void CustomLogger(OutputType type, string output)
+        {
+            if (type == OutputType.Err || output.Contains(": error"))
+                Logger.Error(output);
+            else if (output.Contains(": warning"))
+                Logger.Warn(output);
+            else
+                Logger.Normal(output);
+
+        }
     }
 }
+


### PR DESCRIPTION
Similar to the logger used in DotNetTasks, this one parses the log strings to redirect them to the correct method in the Nuke Logger.
