### PR TITLE
Added support for logger parameters to MSBuild.

### DIFF
--- a/build/specifications/MSBuild.json
+++ b/build/specifications/MSBuild.json
@@ -275,9 +275,162 @@
             "type": "bool",
             "format": "/noconsolelogger",
             "help": "Disable the default console logger, and don't log events to the console."
+          },
+          {
+            "name": "ConsoleLogger",
+            "type": "MSBuildConsoleLoggerParameters",
+            "format": "{value}",
+            "customValue": true,
+            "help": "Specifies parameters for the console logger, which displays build information in the console window."
+          },
+          {
+            "name": "FileLogger",
+            "type": "List<MSBuildFileLoggerParameters>",
+            "format": "{value}",
+            "customValue": true,
+            "help": "Log build output to one or more files. Up to 9 loggers can be added."
           }
         ]
       }
+    }
+  ],
+  "dataClasses": [
+    {
+      "name": "MSBuildConsoleLoggerParameters",
+      "extensionMethods": true,
+      "properties": [
+        {
+          "name": "PerformanceSummary",
+          "type": "bool",
+          "help": " Show the time that's spent in tasks, targets, and projects."
+        },
+        {
+          "name": "Summary",
+          "type": "bool",
+          "help": "Show the error and warning summary at the end."
+        },
+        {
+          "name": "ErrorsOnly",
+          "type": "bool",
+          "help": "Show only errors."
+        },
+        {
+          "name": "WarningsOnly",
+          "type": "bool",
+          "help": "Show only warnings."
+        },
+        {
+          "name": "NoItemAndPropertyList",
+          "type": "bool",
+          "help": "Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic."
+        },
+        {
+          "name": "ShowCommandLine",
+          "type": "bool",
+          "help": "Show TaskCommandLineEvent messages."
+        },
+        {
+          "name": "ShowTimestamp",
+          "type": "bool",
+          "help": "Show the timestamp as a prefix to any message."
+        },
+        {
+          "name": "ShowEventId",
+          "type": "bool",
+          "help": "Show the event ID for each started event, finished event, and message."
+        },
+        {
+          "name": "ForceNoAlign",
+          "type": "bool",
+          "help": "Don't align the text to the size of the console buffer."
+        },
+        {
+          "name": "ConsoleColor",
+          "type": "bool",
+          "help": "If disabled, use the default console colors for all logging messages. (default is enabled)"
+        },
+        {
+          "name": "MultiProcessorLogging",
+          "type": "bool",
+          "help": "Enable/Disable the multiprocessor logging style of output."
+        },
+        {
+          "name": "Verbosity",
+          "type": "MSBuildVerbosity",
+          "help": "Override the -verbosity setting for this logger."
+        }
+      ]
+    },
+    {
+      "name": "MSBuildFileLoggerParameters",
+      "extensionMethods": true,
+      "properties": [
+        {
+          "name": "PerformanceSummary",
+          "type": "bool",
+          "help": " Show the time that's spent in tasks, targets, and projects."
+        },
+        {
+          "name": "Summary",
+          "type": "bool",
+          "help": "Show the error and warning summary at the end."
+        },
+        {
+          "name": "ErrorsOnly",
+          "type": "bool",
+          "help": "Show only errors."
+        },
+        {
+          "name": "WarningsOnly",
+          "type": "bool",
+          "help": "Show only warnings."
+        },
+        {
+          "name": "NoItemAndPropertyList",
+          "type": "bool",
+          "help": "Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic."
+        },
+        {
+          "name": "ShowCommandLine",
+          "type": "bool",
+          "help": "Show TaskCommandLineEvent messages."
+        },
+        {
+          "name": "ShowTimestamp",
+          "type": "bool",
+          "help": "Show the timestamp as a prefix to any message."
+        },
+        {
+          "name": "ShowEventId",
+          "type": "bool",
+          "help": "Show the event ID for each started event, finished event, and message."
+        },
+        {
+          "name": "MultiProcessorLogging",
+          "type": "bool",
+          "help": "Enable/Disable the multiprocessor logging style of output."
+        },
+        {
+          "name": "Verbosity",
+          "type": "MSBuildVerbosity",
+          "help": "Override the -verbosity setting for this logger."
+        },
+        {
+          "name": "LogFile",
+          "type": "string",
+          "help": "The path to the log file into which the build log is written. The distributed file logger prefixes this path to the names of its log files."
+        },
+        {
+          "name": "Append",
+          "type": "bool",
+          "help": "Determines whether the build log is appended to the log file or overwrites it. When you set the switch, the build log is appended to the log file. When the switch is not present, the contents of an existing log file are overwritten."
+        },
+        {
+          "name": "Encoding",
+          "type": "string",
+          "help": "Specifies the encoding for the file (for example, UTF-8, Unicode, or ASCII)."
+        }
+      ]
     }
   ],
   "enumerations": [

--- a/build/specifications/MSBuild.json
+++ b/build/specifications/MSBuild.json
@@ -278,14 +278,14 @@
           },
           {
             "name": "ConsoleLogger",
-            "type": "MSBuildConsoleLoggerParameters",
+            "type": "MSBuildConsoleLogger",
             "format": "{value}",
             "customValue": true,
             "help": "Specifies parameters for the console logger, which displays build information in the console window."
           },
           {
-            "name": "FileLogger",
-            "type": "List<MSBuildFileLoggerParameters>",
+            "name": "FileLoggers",
+            "type": "List<MSBuildFileLogger>",
             "format": "{value}",
             "customValue": true,
             "help": "Log build output to one or more files. Up to 9 loggers can be added."
@@ -296,7 +296,7 @@
   ],
   "dataClasses": [
     {
-      "name": "MSBuildConsoleLoggerParameters",
+      "name": "MSBuildConsoleLogger",
       "extensionMethods": true,
       "properties": [
         {
@@ -357,12 +357,12 @@
         {
           "name": "Verbosity",
           "type": "MSBuildVerbosity",
-          "help": "Override the -verbosity setting for this logger."
+          "help": "Override the <c>-verbosity</c> setting for this logger."
         }
       ]
     },
     {
-      "name": "MSBuildFileLoggerParameters",
+      "name": "MSBuildFileLogger",
       "extensionMethods": true,
       "properties": [
         {
@@ -413,7 +413,7 @@
         {
           "name": "Verbosity",
           "type": "MSBuildVerbosity",
-          "help": "Override the -verbosity setting for this logger."
+          "help": "Override the <c>-verbosity</c> setting for this logger."
         },
         {
           "name": "LogFile",

--- a/source/Nuke.Common/Tools/MSBuild/MSBuild.Generated.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuild.Generated.cs
@@ -52,7 +52,7 @@ namespace Nuke.Common.Tools.MSBuild
         ///   <p>This is a <a href="http://www.nuke.build/docs/authoring-builds/cli-tools.html#fluent-apis">CLI wrapper with fluent API</a> that allows to modify the following arguments:</p>
         ///   <ul>
         ///     <li><c>&lt;consoleLogger&gt;</c> via <see cref="MSBuildSettings.ConsoleLogger"/></li>
-        ///     <li><c>&lt;fileLogger&gt;</c> via <see cref="MSBuildSettings.FileLogger"/></li>
+        ///     <li><c>&lt;fileLoggers&gt;</c> via <see cref="MSBuildSettings.FileLoggers"/></li>
         ///     <li><c>&lt;targetPath&gt;</c> via <see cref="MSBuildSettings.TargetPath"/></li>
         ///     <li><c>/detailedsummary</c> via <see cref="MSBuildSettings.DetailedSummary"/></li>
         ///     <li><c>/logger</c> via <see cref="MSBuildSettings.Loggers"/></li>
@@ -83,7 +83,7 @@ namespace Nuke.Common.Tools.MSBuild
         ///   <p>This is a <a href="http://www.nuke.build/docs/authoring-builds/cli-tools.html#fluent-apis">CLI wrapper with fluent API</a> that allows to modify the following arguments:</p>
         ///   <ul>
         ///     <li><c>&lt;consoleLogger&gt;</c> via <see cref="MSBuildSettings.ConsoleLogger"/></li>
-        ///     <li><c>&lt;fileLogger&gt;</c> via <see cref="MSBuildSettings.FileLogger"/></li>
+        ///     <li><c>&lt;fileLoggers&gt;</c> via <see cref="MSBuildSettings.FileLoggers"/></li>
         ///     <li><c>&lt;targetPath&gt;</c> via <see cref="MSBuildSettings.TargetPath"/></li>
         ///     <li><c>/detailedsummary</c> via <see cref="MSBuildSettings.DetailedSummary"/></li>
         ///     <li><c>/logger</c> via <see cref="MSBuildSettings.Loggers"/></li>
@@ -111,7 +111,7 @@ namespace Nuke.Common.Tools.MSBuild
         ///   <p>This is a <a href="http://www.nuke.build/docs/authoring-builds/cli-tools.html#fluent-apis">CLI wrapper with fluent API</a> that allows to modify the following arguments:</p>
         ///   <ul>
         ///     <li><c>&lt;consoleLogger&gt;</c> via <see cref="MSBuildSettings.ConsoleLogger"/></li>
-        ///     <li><c>&lt;fileLogger&gt;</c> via <see cref="MSBuildSettings.FileLogger"/></li>
+        ///     <li><c>&lt;fileLoggers&gt;</c> via <see cref="MSBuildSettings.FileLoggers"/></li>
         ///     <li><c>&lt;targetPath&gt;</c> via <see cref="MSBuildSettings.TargetPath"/></li>
         ///     <li><c>/detailedsummary</c> via <see cref="MSBuildSettings.DetailedSummary"/></li>
         ///     <li><c>/logger</c> via <see cref="MSBuildSettings.Loggers"/></li>
@@ -212,12 +212,12 @@ namespace Nuke.Common.Tools.MSBuild
         /// <summary>
         ///   Specifies parameters for the console logger, which displays build information in the console window.
         /// </summary>
-        public virtual MSBuildConsoleLoggerParameters ConsoleLogger { get; internal set; }
+        public virtual MSBuildConsoleLogger ConsoleLogger { get; internal set; }
         /// <summary>
         ///   Log build output to one or more files. Up to 9 loggers can be added.
         /// </summary>
-        public virtual IReadOnlyList<MSBuildFileLoggerParameters> FileLogger => FileLoggerInternal.AsReadOnly();
-        internal List<MSBuildFileLoggerParameters> FileLoggerInternal { get; set; } = new List<MSBuildFileLoggerParameters>();
+        public virtual IReadOnlyList<MSBuildFileLogger> FileLoggers => FileLoggersInternal.AsReadOnly();
+        internal List<MSBuildFileLogger> FileLoggersInternal { get; set; } = new List<MSBuildFileLogger>();
         protected override Arguments ConfigureArguments(Arguments arguments)
         {
             arguments
@@ -235,19 +235,19 @@ namespace Nuke.Common.Tools.MSBuild
               .Add("/logger:{value}", Loggers)
               .Add("/noconsolelogger", NoConsoleLogger)
               .Add("{value}", GetConsoleLogger(), customValue: true)
-              .Add("{value}", GetFileLogger(), customValue: true);
+              .Add("{value}", GetFileLoggers(), customValue: true);
             return base.ConfigureArguments(arguments);
         }
     }
     #endregion
-    #region MSBuildConsoleLoggerParameters
+    #region MSBuildConsoleLogger
     /// <summary>
     ///   Used within <see cref="MSBuildTasks"/>.
     /// </summary>
     [PublicAPI]
     [ExcludeFromCodeCoverage]
     [Serializable]
-    public partial class MSBuildConsoleLoggerParameters : ISettingsEntity
+    public partial class MSBuildConsoleLogger : ISettingsEntity
     {
         /// <summary>
         ///    Show the time that's spent in tasks, targets, and projects.
@@ -299,14 +299,14 @@ namespace Nuke.Common.Tools.MSBuild
         public virtual MSBuildVerbosity Verbosity { get; internal set; }
     }
     #endregion
-    #region MSBuildFileLoggerParameters
+    #region MSBuildFileLogger
     /// <summary>
     ///   Used within <see cref="MSBuildTasks"/>.
     /// </summary>
     [PublicAPI]
     [ExcludeFromCodeCoverage]
     [Serializable]
-    public partial class MSBuildFileLoggerParameters : ISettingsEntity
+    public partial class MSBuildFileLogger : ISettingsEntity
     {
         /// <summary>
         ///    Show the time that's spent in tasks, targets, and projects.
@@ -2521,7 +2521,7 @@ namespace Nuke.Common.Tools.MSBuild
         ///   <p>Specifies parameters for the console logger, which displays build information in the console window.</p>
         /// </summary>
         [Pure]
-        public static MSBuildSettings SetConsoleLogger(this MSBuildSettings toolSettings, MSBuildConsoleLoggerParameters consoleLogger)
+        public static MSBuildSettings SetConsoleLogger(this MSBuildSettings toolSettings, MSBuildConsoleLogger consoleLogger)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ConsoleLogger = consoleLogger;
@@ -2539,148 +2539,148 @@ namespace Nuke.Common.Tools.MSBuild
             return toolSettings;
         }
         #endregion
-        #region FileLogger
+        #region FileLoggers
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildSettings.FileLogger"/> to a new list</em></p>
+        ///   <p><em>Sets <see cref="MSBuildSettings.FileLoggers"/> to a new list</em></p>
         ///   <p>Log build output to one or more files. Up to 9 loggers can be added.</p>
         /// </summary>
         [Pure]
-        public static MSBuildSettings SetFileLogger(this MSBuildSettings toolSettings, params MSBuildFileLoggerParameters[] fileLogger)
+        public static MSBuildSettings SetFileLoggers(this MSBuildSettings toolSettings, params MSBuildFileLogger[] fileLoggers)
         {
             toolSettings = toolSettings.NewInstance();
-            toolSettings.FileLoggerInternal = fileLogger.ToList();
+            toolSettings.FileLoggersInternal = fileLoggers.ToList();
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildSettings.FileLogger"/> to a new list</em></p>
+        ///   <p><em>Sets <see cref="MSBuildSettings.FileLoggers"/> to a new list</em></p>
         ///   <p>Log build output to one or more files. Up to 9 loggers can be added.</p>
         /// </summary>
         [Pure]
-        public static MSBuildSettings SetFileLogger(this MSBuildSettings toolSettings, IEnumerable<MSBuildFileLoggerParameters> fileLogger)
+        public static MSBuildSettings SetFileLoggers(this MSBuildSettings toolSettings, IEnumerable<MSBuildFileLogger> fileLoggers)
         {
             toolSettings = toolSettings.NewInstance();
-            toolSettings.FileLoggerInternal = fileLogger.ToList();
+            toolSettings.FileLoggersInternal = fileLoggers.ToList();
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Adds values to <see cref="MSBuildSettings.FileLogger"/></em></p>
+        ///   <p><em>Adds values to <see cref="MSBuildSettings.FileLoggers"/></em></p>
         ///   <p>Log build output to one or more files. Up to 9 loggers can be added.</p>
         /// </summary>
         [Pure]
-        public static MSBuildSettings AddFileLogger(this MSBuildSettings toolSettings, params MSBuildFileLoggerParameters[] fileLogger)
+        public static MSBuildSettings AddFileLoggers(this MSBuildSettings toolSettings, params MSBuildFileLogger[] fileLoggers)
         {
             toolSettings = toolSettings.NewInstance();
-            toolSettings.FileLoggerInternal.AddRange(fileLogger);
+            toolSettings.FileLoggersInternal.AddRange(fileLoggers);
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Adds values to <see cref="MSBuildSettings.FileLogger"/></em></p>
+        ///   <p><em>Adds values to <see cref="MSBuildSettings.FileLoggers"/></em></p>
         ///   <p>Log build output to one or more files. Up to 9 loggers can be added.</p>
         /// </summary>
         [Pure]
-        public static MSBuildSettings AddFileLogger(this MSBuildSettings toolSettings, IEnumerable<MSBuildFileLoggerParameters> fileLogger)
+        public static MSBuildSettings AddFileLoggers(this MSBuildSettings toolSettings, IEnumerable<MSBuildFileLogger> fileLoggers)
         {
             toolSettings = toolSettings.NewInstance();
-            toolSettings.FileLoggerInternal.AddRange(fileLogger);
+            toolSettings.FileLoggersInternal.AddRange(fileLoggers);
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Clears <see cref="MSBuildSettings.FileLogger"/></em></p>
+        ///   <p><em>Clears <see cref="MSBuildSettings.FileLoggers"/></em></p>
         ///   <p>Log build output to one or more files. Up to 9 loggers can be added.</p>
         /// </summary>
         [Pure]
-        public static MSBuildSettings ClearFileLogger(this MSBuildSettings toolSettings)
+        public static MSBuildSettings ClearFileLoggers(this MSBuildSettings toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
-            toolSettings.FileLoggerInternal.Clear();
+            toolSettings.FileLoggersInternal.Clear();
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Removes values from <see cref="MSBuildSettings.FileLogger"/></em></p>
+        ///   <p><em>Removes values from <see cref="MSBuildSettings.FileLoggers"/></em></p>
         ///   <p>Log build output to one or more files. Up to 9 loggers can be added.</p>
         /// </summary>
         [Pure]
-        public static MSBuildSettings RemoveFileLogger(this MSBuildSettings toolSettings, params MSBuildFileLoggerParameters[] fileLogger)
+        public static MSBuildSettings RemoveFileLoggers(this MSBuildSettings toolSettings, params MSBuildFileLogger[] fileLoggers)
         {
             toolSettings = toolSettings.NewInstance();
-            var hashSet = new HashSet<MSBuildFileLoggerParameters>(fileLogger);
-            toolSettings.FileLoggerInternal.RemoveAll(x => hashSet.Contains(x));
+            var hashSet = new HashSet<MSBuildFileLogger>(fileLoggers);
+            toolSettings.FileLoggersInternal.RemoveAll(x => hashSet.Contains(x));
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Removes values from <see cref="MSBuildSettings.FileLogger"/></em></p>
+        ///   <p><em>Removes values from <see cref="MSBuildSettings.FileLoggers"/></em></p>
         ///   <p>Log build output to one or more files. Up to 9 loggers can be added.</p>
         /// </summary>
         [Pure]
-        public static MSBuildSettings RemoveFileLogger(this MSBuildSettings toolSettings, IEnumerable<MSBuildFileLoggerParameters> fileLogger)
+        public static MSBuildSettings RemoveFileLoggers(this MSBuildSettings toolSettings, IEnumerable<MSBuildFileLogger> fileLoggers)
         {
             toolSettings = toolSettings.NewInstance();
-            var hashSet = new HashSet<MSBuildFileLoggerParameters>(fileLogger);
-            toolSettings.FileLoggerInternal.RemoveAll(x => hashSet.Contains(x));
+            var hashSet = new HashSet<MSBuildFileLogger>(fileLoggers);
+            toolSettings.FileLoggersInternal.RemoveAll(x => hashSet.Contains(x));
             return toolSettings;
         }
         #endregion
     }
     #endregion
-    #region MSBuildConsoleLoggerParametersExtensions
+    #region MSBuildConsoleLoggerExtensions
     /// <summary>
     ///   Used within <see cref="MSBuildTasks"/>.
     /// </summary>
     [PublicAPI]
     [ExcludeFromCodeCoverage]
-    public static partial class MSBuildConsoleLoggerParametersExtensions
+    public static partial class MSBuildConsoleLoggerExtensions
     {
         #region PerformanceSummary
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLogger.PerformanceSummary"/></em></p>
         ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters SetPerformanceSummary(this MSBuildConsoleLoggerParameters toolSettings, bool? performanceSummary)
+        public static MSBuildConsoleLogger SetPerformanceSummary(this MSBuildConsoleLogger toolSettings, bool? performanceSummary)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.PerformanceSummary = performanceSummary;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLogger.PerformanceSummary"/></em></p>
         ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ResetPerformanceSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ResetPerformanceSummary(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.PerformanceSummary = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLogger.PerformanceSummary"/></em></p>
         ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters EnablePerformanceSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger EnablePerformanceSummary(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.PerformanceSummary = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLogger.PerformanceSummary"/></em></p>
         ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters DisablePerformanceSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger DisablePerformanceSummary(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.PerformanceSummary = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLogger.PerformanceSummary"/></em></p>
         ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters TogglePerformanceSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger TogglePerformanceSummary(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.PerformanceSummary = !toolSettings.PerformanceSummary;
@@ -2689,55 +2689,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region Summary
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.Summary"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLogger.Summary"/></em></p>
         ///   <p>Show the error and warning summary at the end.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters SetSummary(this MSBuildConsoleLoggerParameters toolSettings, bool? summary)
+        public static MSBuildConsoleLogger SetSummary(this MSBuildConsoleLogger toolSettings, bool? summary)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Summary = summary;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.Summary"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLogger.Summary"/></em></p>
         ///   <p>Show the error and warning summary at the end.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ResetSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ResetSummary(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Summary = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.Summary"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLogger.Summary"/></em></p>
         ///   <p>Show the error and warning summary at the end.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters EnableSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger EnableSummary(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Summary = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.Summary"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLogger.Summary"/></em></p>
         ///   <p>Show the error and warning summary at the end.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters DisableSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger DisableSummary(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Summary = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.Summary"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLogger.Summary"/></em></p>
         ///   <p>Show the error and warning summary at the end.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ToggleSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ToggleSummary(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Summary = !toolSettings.Summary;
@@ -2746,55 +2746,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region ErrorsOnly
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLogger.ErrorsOnly"/></em></p>
         ///   <p>Show only errors.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters SetErrorsOnly(this MSBuildConsoleLoggerParameters toolSettings, bool? errorsOnly)
+        public static MSBuildConsoleLogger SetErrorsOnly(this MSBuildConsoleLogger toolSettings, bool? errorsOnly)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ErrorsOnly = errorsOnly;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLogger.ErrorsOnly"/></em></p>
         ///   <p>Show only errors.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ResetErrorsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ResetErrorsOnly(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ErrorsOnly = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLogger.ErrorsOnly"/></em></p>
         ///   <p>Show only errors.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters EnableErrorsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger EnableErrorsOnly(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ErrorsOnly = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLogger.ErrorsOnly"/></em></p>
         ///   <p>Show only errors.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters DisableErrorsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger DisableErrorsOnly(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ErrorsOnly = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLogger.ErrorsOnly"/></em></p>
         ///   <p>Show only errors.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ToggleErrorsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ToggleErrorsOnly(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ErrorsOnly = !toolSettings.ErrorsOnly;
@@ -2803,55 +2803,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region WarningsOnly
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLogger.WarningsOnly"/></em></p>
         ///   <p>Show only warnings.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters SetWarningsOnly(this MSBuildConsoleLoggerParameters toolSettings, bool? warningsOnly)
+        public static MSBuildConsoleLogger SetWarningsOnly(this MSBuildConsoleLogger toolSettings, bool? warningsOnly)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.WarningsOnly = warningsOnly;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLogger.WarningsOnly"/></em></p>
         ///   <p>Show only warnings.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ResetWarningsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ResetWarningsOnly(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.WarningsOnly = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLogger.WarningsOnly"/></em></p>
         ///   <p>Show only warnings.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters EnableWarningsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger EnableWarningsOnly(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.WarningsOnly = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLogger.WarningsOnly"/></em></p>
         ///   <p>Show only warnings.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters DisableWarningsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger DisableWarningsOnly(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.WarningsOnly = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLogger.WarningsOnly"/></em></p>
         ///   <p>Show only warnings.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ToggleWarningsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ToggleWarningsOnly(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.WarningsOnly = !toolSettings.WarningsOnly;
@@ -2860,55 +2860,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region NoItemAndPropertyList
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLogger.NoItemAndPropertyList"/></em></p>
         ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters SetNoItemAndPropertyList(this MSBuildConsoleLoggerParameters toolSettings, bool? noItemAndPropertyList)
+        public static MSBuildConsoleLogger SetNoItemAndPropertyList(this MSBuildConsoleLogger toolSettings, bool? noItemAndPropertyList)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.NoItemAndPropertyList = noItemAndPropertyList;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLogger.NoItemAndPropertyList"/></em></p>
         ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ResetNoItemAndPropertyList(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ResetNoItemAndPropertyList(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.NoItemAndPropertyList = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLogger.NoItemAndPropertyList"/></em></p>
         ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters EnableNoItemAndPropertyList(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger EnableNoItemAndPropertyList(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.NoItemAndPropertyList = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLogger.NoItemAndPropertyList"/></em></p>
         ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters DisableNoItemAndPropertyList(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger DisableNoItemAndPropertyList(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.NoItemAndPropertyList = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLogger.NoItemAndPropertyList"/></em></p>
         ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ToggleNoItemAndPropertyList(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ToggleNoItemAndPropertyList(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.NoItemAndPropertyList = !toolSettings.NoItemAndPropertyList;
@@ -2917,55 +2917,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region ShowCommandLine
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLogger.ShowCommandLine"/></em></p>
         ///   <p>Show TaskCommandLineEvent messages.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters SetShowCommandLine(this MSBuildConsoleLoggerParameters toolSettings, bool? showCommandLine)
+        public static MSBuildConsoleLogger SetShowCommandLine(this MSBuildConsoleLogger toolSettings, bool? showCommandLine)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowCommandLine = showCommandLine;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLogger.ShowCommandLine"/></em></p>
         ///   <p>Show TaskCommandLineEvent messages.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ResetShowCommandLine(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ResetShowCommandLine(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowCommandLine = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLogger.ShowCommandLine"/></em></p>
         ///   <p>Show TaskCommandLineEvent messages.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters EnableShowCommandLine(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger EnableShowCommandLine(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowCommandLine = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLogger.ShowCommandLine"/></em></p>
         ///   <p>Show TaskCommandLineEvent messages.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters DisableShowCommandLine(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger DisableShowCommandLine(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowCommandLine = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLogger.ShowCommandLine"/></em></p>
         ///   <p>Show TaskCommandLineEvent messages.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ToggleShowCommandLine(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ToggleShowCommandLine(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowCommandLine = !toolSettings.ShowCommandLine;
@@ -2974,55 +2974,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region ShowTimestamp
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLogger.ShowTimestamp"/></em></p>
         ///   <p>Show the timestamp as a prefix to any message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters SetShowTimestamp(this MSBuildConsoleLoggerParameters toolSettings, bool? showTimestamp)
+        public static MSBuildConsoleLogger SetShowTimestamp(this MSBuildConsoleLogger toolSettings, bool? showTimestamp)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowTimestamp = showTimestamp;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLogger.ShowTimestamp"/></em></p>
         ///   <p>Show the timestamp as a prefix to any message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ResetShowTimestamp(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ResetShowTimestamp(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowTimestamp = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLogger.ShowTimestamp"/></em></p>
         ///   <p>Show the timestamp as a prefix to any message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters EnableShowTimestamp(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger EnableShowTimestamp(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowTimestamp = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLogger.ShowTimestamp"/></em></p>
         ///   <p>Show the timestamp as a prefix to any message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters DisableShowTimestamp(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger DisableShowTimestamp(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowTimestamp = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLogger.ShowTimestamp"/></em></p>
         ///   <p>Show the timestamp as a prefix to any message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ToggleShowTimestamp(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ToggleShowTimestamp(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowTimestamp = !toolSettings.ShowTimestamp;
@@ -3031,55 +3031,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region ShowEventId
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.ShowEventId"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLogger.ShowEventId"/></em></p>
         ///   <p>Show the event ID for each started event, finished event, and message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters SetShowEventId(this MSBuildConsoleLoggerParameters toolSettings, bool? showEventId)
+        public static MSBuildConsoleLogger SetShowEventId(this MSBuildConsoleLogger toolSettings, bool? showEventId)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowEventId = showEventId;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.ShowEventId"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLogger.ShowEventId"/></em></p>
         ///   <p>Show the event ID for each started event, finished event, and message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ResetShowEventId(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ResetShowEventId(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowEventId = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.ShowEventId"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLogger.ShowEventId"/></em></p>
         ///   <p>Show the event ID for each started event, finished event, and message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters EnableShowEventId(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger EnableShowEventId(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowEventId = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.ShowEventId"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLogger.ShowEventId"/></em></p>
         ///   <p>Show the event ID for each started event, finished event, and message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters DisableShowEventId(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger DisableShowEventId(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowEventId = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.ShowEventId"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLogger.ShowEventId"/></em></p>
         ///   <p>Show the event ID for each started event, finished event, and message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ToggleShowEventId(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ToggleShowEventId(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowEventId = !toolSettings.ShowEventId;
@@ -3088,55 +3088,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region ForceNoAlign
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.ForceNoAlign"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLogger.ForceNoAlign"/></em></p>
         ///   <p>Don't align the text to the size of the console buffer.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters SetForceNoAlign(this MSBuildConsoleLoggerParameters toolSettings, bool? forceNoAlign)
+        public static MSBuildConsoleLogger SetForceNoAlign(this MSBuildConsoleLogger toolSettings, bool? forceNoAlign)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ForceNoAlign = forceNoAlign;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.ForceNoAlign"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLogger.ForceNoAlign"/></em></p>
         ///   <p>Don't align the text to the size of the console buffer.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ResetForceNoAlign(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ResetForceNoAlign(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ForceNoAlign = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.ForceNoAlign"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLogger.ForceNoAlign"/></em></p>
         ///   <p>Don't align the text to the size of the console buffer.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters EnableForceNoAlign(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger EnableForceNoAlign(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ForceNoAlign = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.ForceNoAlign"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLogger.ForceNoAlign"/></em></p>
         ///   <p>Don't align the text to the size of the console buffer.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters DisableForceNoAlign(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger DisableForceNoAlign(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ForceNoAlign = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.ForceNoAlign"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLogger.ForceNoAlign"/></em></p>
         ///   <p>Don't align the text to the size of the console buffer.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ToggleForceNoAlign(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ToggleForceNoAlign(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ForceNoAlign = !toolSettings.ForceNoAlign;
@@ -3145,55 +3145,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region ConsoleColor
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.ConsoleColor"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLogger.ConsoleColor"/></em></p>
         ///   <p>If disabled, use the default console colors for all logging messages. (default is enabled)</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters SetConsoleColor(this MSBuildConsoleLoggerParameters toolSettings, bool? consoleColor)
+        public static MSBuildConsoleLogger SetConsoleColor(this MSBuildConsoleLogger toolSettings, bool? consoleColor)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ConsoleColor = consoleColor;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.ConsoleColor"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLogger.ConsoleColor"/></em></p>
         ///   <p>If disabled, use the default console colors for all logging messages. (default is enabled)</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ResetConsoleColor(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ResetConsoleColor(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ConsoleColor = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.ConsoleColor"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLogger.ConsoleColor"/></em></p>
         ///   <p>If disabled, use the default console colors for all logging messages. (default is enabled)</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters EnableConsoleColor(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger EnableConsoleColor(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ConsoleColor = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.ConsoleColor"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLogger.ConsoleColor"/></em></p>
         ///   <p>If disabled, use the default console colors for all logging messages. (default is enabled)</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters DisableConsoleColor(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger DisableConsoleColor(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ConsoleColor = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.ConsoleColor"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLogger.ConsoleColor"/></em></p>
         ///   <p>If disabled, use the default console colors for all logging messages. (default is enabled)</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ToggleConsoleColor(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ToggleConsoleColor(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ConsoleColor = !toolSettings.ConsoleColor;
@@ -3202,55 +3202,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region MultiProcessorLogging
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLogger.MultiProcessorLogging"/></em></p>
         ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters SetMultiProcessorLogging(this MSBuildConsoleLoggerParameters toolSettings, bool? multiProcessorLogging)
+        public static MSBuildConsoleLogger SetMultiProcessorLogging(this MSBuildConsoleLogger toolSettings, bool? multiProcessorLogging)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.MultiProcessorLogging = multiProcessorLogging;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLogger.MultiProcessorLogging"/></em></p>
         ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ResetMultiProcessorLogging(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ResetMultiProcessorLogging(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.MultiProcessorLogging = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLogger.MultiProcessorLogging"/></em></p>
         ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters EnableMultiProcessorLogging(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger EnableMultiProcessorLogging(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.MultiProcessorLogging = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLogger.MultiProcessorLogging"/></em></p>
         ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters DisableMultiProcessorLogging(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger DisableMultiProcessorLogging(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.MultiProcessorLogging = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLogger.MultiProcessorLogging"/></em></p>
         ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ToggleMultiProcessorLogging(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ToggleMultiProcessorLogging(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.MultiProcessorLogging = !toolSettings.MultiProcessorLogging;
@@ -3259,22 +3259,22 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region Verbosity
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.Verbosity"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLogger.Verbosity"/></em></p>
         ///   <p>Override the -verbosity setting for this logger.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters SetVerbosity(this MSBuildConsoleLoggerParameters toolSettings, MSBuildVerbosity verbosity)
+        public static MSBuildConsoleLogger SetVerbosity(this MSBuildConsoleLogger toolSettings, MSBuildVerbosity verbosity)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Verbosity = verbosity;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.Verbosity"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLogger.Verbosity"/></em></p>
         ///   <p>Override the -verbosity setting for this logger.</p>
         /// </summary>
         [Pure]
-        public static MSBuildConsoleLoggerParameters ResetVerbosity(this MSBuildConsoleLoggerParameters toolSettings)
+        public static MSBuildConsoleLogger ResetVerbosity(this MSBuildConsoleLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Verbosity = null;
@@ -3283,65 +3283,65 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
     }
     #endregion
-    #region MSBuildFileLoggerParametersExtensions
+    #region MSBuildFileLoggerExtensions
     /// <summary>
     ///   Used within <see cref="MSBuildTasks"/>.
     /// </summary>
     [PublicAPI]
     [ExcludeFromCodeCoverage]
-    public static partial class MSBuildFileLoggerParametersExtensions
+    public static partial class MSBuildFileLoggerExtensions
     {
         #region PerformanceSummary
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildFileLogger.PerformanceSummary"/></em></p>
         ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters SetPerformanceSummary(this MSBuildFileLoggerParameters toolSettings, bool? performanceSummary)
+        public static MSBuildFileLogger SetPerformanceSummary(this MSBuildFileLogger toolSettings, bool? performanceSummary)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.PerformanceSummary = performanceSummary;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildFileLogger.PerformanceSummary"/></em></p>
         ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ResetPerformanceSummary(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ResetPerformanceSummary(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.PerformanceSummary = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildFileLogger.PerformanceSummary"/></em></p>
         ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters EnablePerformanceSummary(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger EnablePerformanceSummary(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.PerformanceSummary = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildFileLogger.PerformanceSummary"/></em></p>
         ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters DisablePerformanceSummary(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger DisablePerformanceSummary(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.PerformanceSummary = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildFileLogger.PerformanceSummary"/></em></p>
         ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters TogglePerformanceSummary(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger TogglePerformanceSummary(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.PerformanceSummary = !toolSettings.PerformanceSummary;
@@ -3350,55 +3350,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region Summary
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.Summary"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildFileLogger.Summary"/></em></p>
         ///   <p>Show the error and warning summary at the end.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters SetSummary(this MSBuildFileLoggerParameters toolSettings, bool? summary)
+        public static MSBuildFileLogger SetSummary(this MSBuildFileLogger toolSettings, bool? summary)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Summary = summary;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.Summary"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildFileLogger.Summary"/></em></p>
         ///   <p>Show the error and warning summary at the end.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ResetSummary(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ResetSummary(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Summary = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.Summary"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildFileLogger.Summary"/></em></p>
         ///   <p>Show the error and warning summary at the end.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters EnableSummary(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger EnableSummary(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Summary = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.Summary"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildFileLogger.Summary"/></em></p>
         ///   <p>Show the error and warning summary at the end.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters DisableSummary(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger DisableSummary(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Summary = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.Summary"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildFileLogger.Summary"/></em></p>
         ///   <p>Show the error and warning summary at the end.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ToggleSummary(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ToggleSummary(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Summary = !toolSettings.Summary;
@@ -3407,55 +3407,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region ErrorsOnly
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildFileLogger.ErrorsOnly"/></em></p>
         ///   <p>Show only errors.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters SetErrorsOnly(this MSBuildFileLoggerParameters toolSettings, bool? errorsOnly)
+        public static MSBuildFileLogger SetErrorsOnly(this MSBuildFileLogger toolSettings, bool? errorsOnly)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ErrorsOnly = errorsOnly;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildFileLogger.ErrorsOnly"/></em></p>
         ///   <p>Show only errors.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ResetErrorsOnly(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ResetErrorsOnly(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ErrorsOnly = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildFileLogger.ErrorsOnly"/></em></p>
         ///   <p>Show only errors.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters EnableErrorsOnly(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger EnableErrorsOnly(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ErrorsOnly = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildFileLogger.ErrorsOnly"/></em></p>
         ///   <p>Show only errors.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters DisableErrorsOnly(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger DisableErrorsOnly(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ErrorsOnly = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildFileLogger.ErrorsOnly"/></em></p>
         ///   <p>Show only errors.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ToggleErrorsOnly(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ToggleErrorsOnly(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ErrorsOnly = !toolSettings.ErrorsOnly;
@@ -3464,55 +3464,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region WarningsOnly
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildFileLogger.WarningsOnly"/></em></p>
         ///   <p>Show only warnings.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters SetWarningsOnly(this MSBuildFileLoggerParameters toolSettings, bool? warningsOnly)
+        public static MSBuildFileLogger SetWarningsOnly(this MSBuildFileLogger toolSettings, bool? warningsOnly)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.WarningsOnly = warningsOnly;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildFileLogger.WarningsOnly"/></em></p>
         ///   <p>Show only warnings.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ResetWarningsOnly(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ResetWarningsOnly(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.WarningsOnly = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildFileLogger.WarningsOnly"/></em></p>
         ///   <p>Show only warnings.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters EnableWarningsOnly(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger EnableWarningsOnly(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.WarningsOnly = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildFileLogger.WarningsOnly"/></em></p>
         ///   <p>Show only warnings.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters DisableWarningsOnly(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger DisableWarningsOnly(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.WarningsOnly = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildFileLogger.WarningsOnly"/></em></p>
         ///   <p>Show only warnings.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ToggleWarningsOnly(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ToggleWarningsOnly(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.WarningsOnly = !toolSettings.WarningsOnly;
@@ -3521,55 +3521,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region NoItemAndPropertyList
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildFileLogger.NoItemAndPropertyList"/></em></p>
         ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters SetNoItemAndPropertyList(this MSBuildFileLoggerParameters toolSettings, bool? noItemAndPropertyList)
+        public static MSBuildFileLogger SetNoItemAndPropertyList(this MSBuildFileLogger toolSettings, bool? noItemAndPropertyList)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.NoItemAndPropertyList = noItemAndPropertyList;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildFileLogger.NoItemAndPropertyList"/></em></p>
         ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ResetNoItemAndPropertyList(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ResetNoItemAndPropertyList(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.NoItemAndPropertyList = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildFileLogger.NoItemAndPropertyList"/></em></p>
         ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters EnableNoItemAndPropertyList(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger EnableNoItemAndPropertyList(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.NoItemAndPropertyList = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildFileLogger.NoItemAndPropertyList"/></em></p>
         ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters DisableNoItemAndPropertyList(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger DisableNoItemAndPropertyList(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.NoItemAndPropertyList = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildFileLogger.NoItemAndPropertyList"/></em></p>
         ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ToggleNoItemAndPropertyList(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ToggleNoItemAndPropertyList(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.NoItemAndPropertyList = !toolSettings.NoItemAndPropertyList;
@@ -3578,55 +3578,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region ShowCommandLine
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildFileLogger.ShowCommandLine"/></em></p>
         ///   <p>Show TaskCommandLineEvent messages.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters SetShowCommandLine(this MSBuildFileLoggerParameters toolSettings, bool? showCommandLine)
+        public static MSBuildFileLogger SetShowCommandLine(this MSBuildFileLogger toolSettings, bool? showCommandLine)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowCommandLine = showCommandLine;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildFileLogger.ShowCommandLine"/></em></p>
         ///   <p>Show TaskCommandLineEvent messages.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ResetShowCommandLine(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ResetShowCommandLine(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowCommandLine = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildFileLogger.ShowCommandLine"/></em></p>
         ///   <p>Show TaskCommandLineEvent messages.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters EnableShowCommandLine(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger EnableShowCommandLine(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowCommandLine = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildFileLogger.ShowCommandLine"/></em></p>
         ///   <p>Show TaskCommandLineEvent messages.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters DisableShowCommandLine(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger DisableShowCommandLine(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowCommandLine = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildFileLogger.ShowCommandLine"/></em></p>
         ///   <p>Show TaskCommandLineEvent messages.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ToggleShowCommandLine(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ToggleShowCommandLine(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowCommandLine = !toolSettings.ShowCommandLine;
@@ -3635,55 +3635,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region ShowTimestamp
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildFileLogger.ShowTimestamp"/></em></p>
         ///   <p>Show the timestamp as a prefix to any message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters SetShowTimestamp(this MSBuildFileLoggerParameters toolSettings, bool? showTimestamp)
+        public static MSBuildFileLogger SetShowTimestamp(this MSBuildFileLogger toolSettings, bool? showTimestamp)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowTimestamp = showTimestamp;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildFileLogger.ShowTimestamp"/></em></p>
         ///   <p>Show the timestamp as a prefix to any message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ResetShowTimestamp(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ResetShowTimestamp(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowTimestamp = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildFileLogger.ShowTimestamp"/></em></p>
         ///   <p>Show the timestamp as a prefix to any message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters EnableShowTimestamp(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger EnableShowTimestamp(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowTimestamp = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildFileLogger.ShowTimestamp"/></em></p>
         ///   <p>Show the timestamp as a prefix to any message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters DisableShowTimestamp(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger DisableShowTimestamp(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowTimestamp = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildFileLogger.ShowTimestamp"/></em></p>
         ///   <p>Show the timestamp as a prefix to any message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ToggleShowTimestamp(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ToggleShowTimestamp(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowTimestamp = !toolSettings.ShowTimestamp;
@@ -3692,55 +3692,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region ShowEventId
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.ShowEventId"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildFileLogger.ShowEventId"/></em></p>
         ///   <p>Show the event ID for each started event, finished event, and message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters SetShowEventId(this MSBuildFileLoggerParameters toolSettings, bool? showEventId)
+        public static MSBuildFileLogger SetShowEventId(this MSBuildFileLogger toolSettings, bool? showEventId)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowEventId = showEventId;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.ShowEventId"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildFileLogger.ShowEventId"/></em></p>
         ///   <p>Show the event ID for each started event, finished event, and message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ResetShowEventId(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ResetShowEventId(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowEventId = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.ShowEventId"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildFileLogger.ShowEventId"/></em></p>
         ///   <p>Show the event ID for each started event, finished event, and message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters EnableShowEventId(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger EnableShowEventId(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowEventId = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.ShowEventId"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildFileLogger.ShowEventId"/></em></p>
         ///   <p>Show the event ID for each started event, finished event, and message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters DisableShowEventId(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger DisableShowEventId(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowEventId = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.ShowEventId"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildFileLogger.ShowEventId"/></em></p>
         ///   <p>Show the event ID for each started event, finished event, and message.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ToggleShowEventId(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ToggleShowEventId(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.ShowEventId = !toolSettings.ShowEventId;
@@ -3749,55 +3749,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region MultiProcessorLogging
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildFileLogger.MultiProcessorLogging"/></em></p>
         ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters SetMultiProcessorLogging(this MSBuildFileLoggerParameters toolSettings, bool? multiProcessorLogging)
+        public static MSBuildFileLogger SetMultiProcessorLogging(this MSBuildFileLogger toolSettings, bool? multiProcessorLogging)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.MultiProcessorLogging = multiProcessorLogging;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildFileLogger.MultiProcessorLogging"/></em></p>
         ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ResetMultiProcessorLogging(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ResetMultiProcessorLogging(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.MultiProcessorLogging = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildFileLogger.MultiProcessorLogging"/></em></p>
         ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters EnableMultiProcessorLogging(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger EnableMultiProcessorLogging(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.MultiProcessorLogging = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildFileLogger.MultiProcessorLogging"/></em></p>
         ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters DisableMultiProcessorLogging(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger DisableMultiProcessorLogging(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.MultiProcessorLogging = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildFileLogger.MultiProcessorLogging"/></em></p>
         ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ToggleMultiProcessorLogging(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ToggleMultiProcessorLogging(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.MultiProcessorLogging = !toolSettings.MultiProcessorLogging;
@@ -3806,22 +3806,22 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region Verbosity
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.Verbosity"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildFileLogger.Verbosity"/></em></p>
         ///   <p>Override the -verbosity setting for this logger.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters SetVerbosity(this MSBuildFileLoggerParameters toolSettings, MSBuildVerbosity verbosity)
+        public static MSBuildFileLogger SetVerbosity(this MSBuildFileLogger toolSettings, MSBuildVerbosity verbosity)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Verbosity = verbosity;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.Verbosity"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildFileLogger.Verbosity"/></em></p>
         ///   <p>Override the -verbosity setting for this logger.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ResetVerbosity(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ResetVerbosity(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Verbosity = null;
@@ -3830,22 +3830,22 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region LogFile
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.LogFile"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildFileLogger.LogFile"/></em></p>
         ///   <p>The path to the log file into which the build log is written. The distributed file logger prefixes this path to the names of its log files.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters SetLogFile(this MSBuildFileLoggerParameters toolSettings, string logFile)
+        public static MSBuildFileLogger SetLogFile(this MSBuildFileLogger toolSettings, string logFile)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.LogFile = logFile;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.LogFile"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildFileLogger.LogFile"/></em></p>
         ///   <p>The path to the log file into which the build log is written. The distributed file logger prefixes this path to the names of its log files.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ResetLogFile(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ResetLogFile(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.LogFile = null;
@@ -3854,55 +3854,55 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region Append
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.Append"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildFileLogger.Append"/></em></p>
         ///   <p>Determines whether the build log is appended to the log file or overwrites it. When you set the switch, the build log is appended to the log file. When the switch is not present, the contents of an existing log file are overwritten.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters SetAppend(this MSBuildFileLoggerParameters toolSettings, bool? append)
+        public static MSBuildFileLogger SetAppend(this MSBuildFileLogger toolSettings, bool? append)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Append = append;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.Append"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildFileLogger.Append"/></em></p>
         ///   <p>Determines whether the build log is appended to the log file or overwrites it. When you set the switch, the build log is appended to the log file. When the switch is not present, the contents of an existing log file are overwritten.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ResetAppend(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ResetAppend(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Append = null;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.Append"/></em></p>
+        ///   <p><em>Enables <see cref="MSBuildFileLogger.Append"/></em></p>
         ///   <p>Determines whether the build log is appended to the log file or overwrites it. When you set the switch, the build log is appended to the log file. When the switch is not present, the contents of an existing log file are overwritten.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters EnableAppend(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger EnableAppend(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Append = true;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.Append"/></em></p>
+        ///   <p><em>Disables <see cref="MSBuildFileLogger.Append"/></em></p>
         ///   <p>Determines whether the build log is appended to the log file or overwrites it. When you set the switch, the build log is appended to the log file. When the switch is not present, the contents of an existing log file are overwritten.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters DisableAppend(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger DisableAppend(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Append = false;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.Append"/></em></p>
+        ///   <p><em>Toggles <see cref="MSBuildFileLogger.Append"/></em></p>
         ///   <p>Determines whether the build log is appended to the log file or overwrites it. When you set the switch, the build log is appended to the log file. When the switch is not present, the contents of an existing log file are overwritten.</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ToggleAppend(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ToggleAppend(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Append = !toolSettings.Append;
@@ -3911,22 +3911,22 @@ namespace Nuke.Common.Tools.MSBuild
         #endregion
         #region Encoding
         /// <summary>
-        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.Encoding"/></em></p>
+        ///   <p><em>Sets <see cref="MSBuildFileLogger.Encoding"/></em></p>
         ///   <p>Specifies the encoding for the file (for example, UTF-8, Unicode, or ASCII).</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters SetEncoding(this MSBuildFileLoggerParameters toolSettings, string encoding)
+        public static MSBuildFileLogger SetEncoding(this MSBuildFileLogger toolSettings, string encoding)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Encoding = encoding;
             return toolSettings;
         }
         /// <summary>
-        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.Encoding"/></em></p>
+        ///   <p><em>Resets <see cref="MSBuildFileLogger.Encoding"/></em></p>
         ///   <p>Specifies the encoding for the file (for example, UTF-8, Unicode, or ASCII).</p>
         /// </summary>
         [Pure]
-        public static MSBuildFileLoggerParameters ResetEncoding(this MSBuildFileLoggerParameters toolSettings)
+        public static MSBuildFileLogger ResetEncoding(this MSBuildFileLogger toolSettings)
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.Encoding = null;

--- a/source/Nuke.Common/Tools/MSBuild/MSBuild.Generated.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuild.Generated.cs
@@ -1,5 +1,5 @@
-// Generated from https://github.com/nuke-build/common/blob/master/build/specifications/MSBuild.json
-// Generated with Nuke.CodeGeneration version LOCAL (OSX,.NETStandard,Version=v2.0)
+// Generated from https://github.com/alphaleonis/nuke-build-common/blob/master/build/specifications/MSBuild.json
+// Generated with Nuke.CodeGeneration version LOCAL (Windows,.NETStandard,Version=v2.0)
 
 using JetBrains.Annotations;
 using Newtonsoft.Json;
@@ -51,6 +51,8 @@ namespace Nuke.Common.Tools.MSBuild
         /// <remarks>
         ///   <p>This is a <a href="http://www.nuke.build/docs/authoring-builds/cli-tools.html#fluent-apis">CLI wrapper with fluent API</a> that allows to modify the following arguments:</p>
         ///   <ul>
+        ///     <li><c>&lt;consoleLogger&gt;</c> via <see cref="MSBuildSettings.ConsoleLogger"/></li>
+        ///     <li><c>&lt;fileLogger&gt;</c> via <see cref="MSBuildSettings.FileLogger"/></li>
         ///     <li><c>&lt;targetPath&gt;</c> via <see cref="MSBuildSettings.TargetPath"/></li>
         ///     <li><c>/detailedsummary</c> via <see cref="MSBuildSettings.DetailedSummary"/></li>
         ///     <li><c>/logger</c> via <see cref="MSBuildSettings.Loggers"/></li>
@@ -80,6 +82,8 @@ namespace Nuke.Common.Tools.MSBuild
         /// <remarks>
         ///   <p>This is a <a href="http://www.nuke.build/docs/authoring-builds/cli-tools.html#fluent-apis">CLI wrapper with fluent API</a> that allows to modify the following arguments:</p>
         ///   <ul>
+        ///     <li><c>&lt;consoleLogger&gt;</c> via <see cref="MSBuildSettings.ConsoleLogger"/></li>
+        ///     <li><c>&lt;fileLogger&gt;</c> via <see cref="MSBuildSettings.FileLogger"/></li>
         ///     <li><c>&lt;targetPath&gt;</c> via <see cref="MSBuildSettings.TargetPath"/></li>
         ///     <li><c>/detailedsummary</c> via <see cref="MSBuildSettings.DetailedSummary"/></li>
         ///     <li><c>/logger</c> via <see cref="MSBuildSettings.Loggers"/></li>
@@ -106,6 +110,8 @@ namespace Nuke.Common.Tools.MSBuild
         /// <remarks>
         ///   <p>This is a <a href="http://www.nuke.build/docs/authoring-builds/cli-tools.html#fluent-apis">CLI wrapper with fluent API</a> that allows to modify the following arguments:</p>
         ///   <ul>
+        ///     <li><c>&lt;consoleLogger&gt;</c> via <see cref="MSBuildSettings.ConsoleLogger"/></li>
+        ///     <li><c>&lt;fileLogger&gt;</c> via <see cref="MSBuildSettings.FileLogger"/></li>
         ///     <li><c>&lt;targetPath&gt;</c> via <see cref="MSBuildSettings.TargetPath"/></li>
         ///     <li><c>/detailedsummary</c> via <see cref="MSBuildSettings.DetailedSummary"/></li>
         ///     <li><c>/logger</c> via <see cref="MSBuildSettings.Loggers"/></li>
@@ -203,6 +209,15 @@ namespace Nuke.Common.Tools.MSBuild
         ///   Disable the default console logger, and don't log events to the console.
         /// </summary>
         public virtual bool? NoConsoleLogger { get; internal set; }
+        /// <summary>
+        ///   Specifies parameters for the console logger, which displays build information in the console window.
+        /// </summary>
+        public virtual MSBuildConsoleLoggerParameters ConsoleLogger { get; internal set; }
+        /// <summary>
+        ///   Log build output to one or more files. Up to 9 loggers can be added.
+        /// </summary>
+        public virtual IReadOnlyList<MSBuildFileLoggerParameters> FileLogger => FileLoggerInternal.AsReadOnly();
+        internal List<MSBuildFileLoggerParameters> FileLoggerInternal { get; set; } = new List<MSBuildFileLoggerParameters>();
         protected override Arguments ConfigureArguments(Arguments arguments)
         {
             arguments
@@ -218,9 +233,133 @@ namespace Nuke.Common.Tools.MSBuild
               .Add("/toolsversion:{value}", ToolsVersion)
               .Add("/verbosity:{value}", Verbosity)
               .Add("/logger:{value}", Loggers)
-              .Add("/noconsolelogger", NoConsoleLogger);
+              .Add("/noconsolelogger", NoConsoleLogger)
+              .Add("{value}", GetConsoleLogger(), customValue: true)
+              .Add("{value}", GetFileLogger(), customValue: true);
             return base.ConfigureArguments(arguments);
         }
+    }
+    #endregion
+    #region MSBuildConsoleLoggerParameters
+    /// <summary>
+    ///   Used within <see cref="MSBuildTasks"/>.
+    /// </summary>
+    [PublicAPI]
+    [ExcludeFromCodeCoverage]
+    [Serializable]
+    public partial class MSBuildConsoleLoggerParameters : ISettingsEntity
+    {
+        /// <summary>
+        ///    Show the time that's spent in tasks, targets, and projects.
+        /// </summary>
+        public virtual bool? PerformanceSummary { get; internal set; }
+        /// <summary>
+        ///   Show the error and warning summary at the end.
+        /// </summary>
+        public virtual bool? Summary { get; internal set; }
+        /// <summary>
+        ///   Show only errors.
+        /// </summary>
+        public virtual bool? ErrorsOnly { get; internal set; }
+        /// <summary>
+        ///   Show only warnings.
+        /// </summary>
+        public virtual bool? WarningsOnly { get; internal set; }
+        /// <summary>
+        ///   Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.
+        /// </summary>
+        public virtual bool? NoItemAndPropertyList { get; internal set; }
+        /// <summary>
+        ///   Show TaskCommandLineEvent messages.
+        /// </summary>
+        public virtual bool? ShowCommandLine { get; internal set; }
+        /// <summary>
+        ///   Show the timestamp as a prefix to any message.
+        /// </summary>
+        public virtual bool? ShowTimestamp { get; internal set; }
+        /// <summary>
+        ///   Show the event ID for each started event, finished event, and message.
+        /// </summary>
+        public virtual bool? ShowEventId { get; internal set; }
+        /// <summary>
+        ///   Don't align the text to the size of the console buffer.
+        /// </summary>
+        public virtual bool? ForceNoAlign { get; internal set; }
+        /// <summary>
+        ///   If disabled, use the default console colors for all logging messages. (default is enabled)
+        /// </summary>
+        public virtual bool? ConsoleColor { get; internal set; }
+        /// <summary>
+        ///   Enable/Disable the multiprocessor logging style of output.
+        /// </summary>
+        public virtual bool? MultiProcessorLogging { get; internal set; }
+        /// <summary>
+        ///   Override the -verbosity setting for this logger.
+        /// </summary>
+        public virtual MSBuildVerbosity Verbosity { get; internal set; }
+    }
+    #endregion
+    #region MSBuildFileLoggerParameters
+    /// <summary>
+    ///   Used within <see cref="MSBuildTasks"/>.
+    /// </summary>
+    [PublicAPI]
+    [ExcludeFromCodeCoverage]
+    [Serializable]
+    public partial class MSBuildFileLoggerParameters : ISettingsEntity
+    {
+        /// <summary>
+        ///    Show the time that's spent in tasks, targets, and projects.
+        /// </summary>
+        public virtual bool? PerformanceSummary { get; internal set; }
+        /// <summary>
+        ///   Show the error and warning summary at the end.
+        /// </summary>
+        public virtual bool? Summary { get; internal set; }
+        /// <summary>
+        ///   Show only errors.
+        /// </summary>
+        public virtual bool? ErrorsOnly { get; internal set; }
+        /// <summary>
+        ///   Show only warnings.
+        /// </summary>
+        public virtual bool? WarningsOnly { get; internal set; }
+        /// <summary>
+        ///   Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.
+        /// </summary>
+        public virtual bool? NoItemAndPropertyList { get; internal set; }
+        /// <summary>
+        ///   Show TaskCommandLineEvent messages.
+        /// </summary>
+        public virtual bool? ShowCommandLine { get; internal set; }
+        /// <summary>
+        ///   Show the timestamp as a prefix to any message.
+        /// </summary>
+        public virtual bool? ShowTimestamp { get; internal set; }
+        /// <summary>
+        ///   Show the event ID for each started event, finished event, and message.
+        /// </summary>
+        public virtual bool? ShowEventId { get; internal set; }
+        /// <summary>
+        ///   Enable/Disable the multiprocessor logging style of output.
+        /// </summary>
+        public virtual bool? MultiProcessorLogging { get; internal set; }
+        /// <summary>
+        ///   Override the -verbosity setting for this logger.
+        /// </summary>
+        public virtual MSBuildVerbosity Verbosity { get; internal set; }
+        /// <summary>
+        ///   The path to the log file into which the build log is written. The distributed file logger prefixes this path to the names of its log files.
+        /// </summary>
+        public virtual string LogFile { get; internal set; }
+        /// <summary>
+        ///   Determines whether the build log is appended to the log file or overwrites it. When you set the switch, the build log is appended to the log file. When the switch is not present, the contents of an existing log file are overwritten.
+        /// </summary>
+        public virtual bool? Append { get; internal set; }
+        /// <summary>
+        ///   Specifies the encoding for the file (for example, UTF-8, Unicode, or ASCII).
+        /// </summary>
+        public virtual string Encoding { get; internal set; }
     }
     #endregion
     #region MSBuildSettingsExtensions
@@ -2373,6 +2512,1424 @@ namespace Nuke.Common.Tools.MSBuild
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.NoConsoleLogger = !toolSettings.NoConsoleLogger;
+            return toolSettings;
+        }
+        #endregion
+        #region ConsoleLogger
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildSettings.ConsoleLogger"/></em></p>
+        ///   <p>Specifies parameters for the console logger, which displays build information in the console window.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildSettings SetConsoleLogger(this MSBuildSettings toolSettings, MSBuildConsoleLoggerParameters consoleLogger)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ConsoleLogger = consoleLogger;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildSettings.ConsoleLogger"/></em></p>
+        ///   <p>Specifies parameters for the console logger, which displays build information in the console window.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildSettings ResetConsoleLogger(this MSBuildSettings toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ConsoleLogger = null;
+            return toolSettings;
+        }
+        #endregion
+        #region FileLogger
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildSettings.FileLogger"/> to a new list</em></p>
+        ///   <p>Log build output to one or more files. Up to 9 loggers can be added.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildSettings SetFileLogger(this MSBuildSettings toolSettings, params MSBuildFileLoggerParameters[] fileLogger)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.FileLoggerInternal = fileLogger.ToList();
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildSettings.FileLogger"/> to a new list</em></p>
+        ///   <p>Log build output to one or more files. Up to 9 loggers can be added.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildSettings SetFileLogger(this MSBuildSettings toolSettings, IEnumerable<MSBuildFileLoggerParameters> fileLogger)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.FileLoggerInternal = fileLogger.ToList();
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Adds values to <see cref="MSBuildSettings.FileLogger"/></em></p>
+        ///   <p>Log build output to one or more files. Up to 9 loggers can be added.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildSettings AddFileLogger(this MSBuildSettings toolSettings, params MSBuildFileLoggerParameters[] fileLogger)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.FileLoggerInternal.AddRange(fileLogger);
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Adds values to <see cref="MSBuildSettings.FileLogger"/></em></p>
+        ///   <p>Log build output to one or more files. Up to 9 loggers can be added.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildSettings AddFileLogger(this MSBuildSettings toolSettings, IEnumerable<MSBuildFileLoggerParameters> fileLogger)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.FileLoggerInternal.AddRange(fileLogger);
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Clears <see cref="MSBuildSettings.FileLogger"/></em></p>
+        ///   <p>Log build output to one or more files. Up to 9 loggers can be added.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildSettings ClearFileLogger(this MSBuildSettings toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.FileLoggerInternal.Clear();
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Removes values from <see cref="MSBuildSettings.FileLogger"/></em></p>
+        ///   <p>Log build output to one or more files. Up to 9 loggers can be added.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildSettings RemoveFileLogger(this MSBuildSettings toolSettings, params MSBuildFileLoggerParameters[] fileLogger)
+        {
+            toolSettings = toolSettings.NewInstance();
+            var hashSet = new HashSet<MSBuildFileLoggerParameters>(fileLogger);
+            toolSettings.FileLoggerInternal.RemoveAll(x => hashSet.Contains(x));
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Removes values from <see cref="MSBuildSettings.FileLogger"/></em></p>
+        ///   <p>Log build output to one or more files. Up to 9 loggers can be added.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildSettings RemoveFileLogger(this MSBuildSettings toolSettings, IEnumerable<MSBuildFileLoggerParameters> fileLogger)
+        {
+            toolSettings = toolSettings.NewInstance();
+            var hashSet = new HashSet<MSBuildFileLoggerParameters>(fileLogger);
+            toolSettings.FileLoggerInternal.RemoveAll(x => hashSet.Contains(x));
+            return toolSettings;
+        }
+        #endregion
+    }
+    #endregion
+    #region MSBuildConsoleLoggerParametersExtensions
+    /// <summary>
+    ///   Used within <see cref="MSBuildTasks"/>.
+    /// </summary>
+    [PublicAPI]
+    [ExcludeFromCodeCoverage]
+    public static partial class MSBuildConsoleLoggerParametersExtensions
+    {
+        #region PerformanceSummary
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters SetPerformanceSummary(this MSBuildConsoleLoggerParameters toolSettings, bool? performanceSummary)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.PerformanceSummary = performanceSummary;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ResetPerformanceSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.PerformanceSummary = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters EnablePerformanceSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.PerformanceSummary = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters DisablePerformanceSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.PerformanceSummary = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters TogglePerformanceSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.PerformanceSummary = !toolSettings.PerformanceSummary;
+            return toolSettings;
+        }
+        #endregion
+        #region Summary
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.Summary"/></em></p>
+        ///   <p>Show the error and warning summary at the end.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters SetSummary(this MSBuildConsoleLoggerParameters toolSettings, bool? summary)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Summary = summary;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.Summary"/></em></p>
+        ///   <p>Show the error and warning summary at the end.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ResetSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Summary = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.Summary"/></em></p>
+        ///   <p>Show the error and warning summary at the end.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters EnableSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Summary = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.Summary"/></em></p>
+        ///   <p>Show the error and warning summary at the end.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters DisableSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Summary = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.Summary"/></em></p>
+        ///   <p>Show the error and warning summary at the end.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ToggleSummary(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Summary = !toolSettings.Summary;
+            return toolSettings;
+        }
+        #endregion
+        #region ErrorsOnly
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p>Show only errors.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters SetErrorsOnly(this MSBuildConsoleLoggerParameters toolSettings, bool? errorsOnly)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ErrorsOnly = errorsOnly;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p>Show only errors.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ResetErrorsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ErrorsOnly = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p>Show only errors.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters EnableErrorsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ErrorsOnly = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p>Show only errors.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters DisableErrorsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ErrorsOnly = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p>Show only errors.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ToggleErrorsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ErrorsOnly = !toolSettings.ErrorsOnly;
+            return toolSettings;
+        }
+        #endregion
+        #region WarningsOnly
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p>Show only warnings.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters SetWarningsOnly(this MSBuildConsoleLoggerParameters toolSettings, bool? warningsOnly)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.WarningsOnly = warningsOnly;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p>Show only warnings.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ResetWarningsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.WarningsOnly = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p>Show only warnings.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters EnableWarningsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.WarningsOnly = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p>Show only warnings.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters DisableWarningsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.WarningsOnly = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p>Show only warnings.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ToggleWarningsOnly(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.WarningsOnly = !toolSettings.WarningsOnly;
+            return toolSettings;
+        }
+        #endregion
+        #region NoItemAndPropertyList
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters SetNoItemAndPropertyList(this MSBuildConsoleLoggerParameters toolSettings, bool? noItemAndPropertyList)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.NoItemAndPropertyList = noItemAndPropertyList;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ResetNoItemAndPropertyList(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.NoItemAndPropertyList = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters EnableNoItemAndPropertyList(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.NoItemAndPropertyList = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters DisableNoItemAndPropertyList(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.NoItemAndPropertyList = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ToggleNoItemAndPropertyList(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.NoItemAndPropertyList = !toolSettings.NoItemAndPropertyList;
+            return toolSettings;
+        }
+        #endregion
+        #region ShowCommandLine
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p>Show TaskCommandLineEvent messages.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters SetShowCommandLine(this MSBuildConsoleLoggerParameters toolSettings, bool? showCommandLine)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowCommandLine = showCommandLine;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p>Show TaskCommandLineEvent messages.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ResetShowCommandLine(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowCommandLine = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p>Show TaskCommandLineEvent messages.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters EnableShowCommandLine(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowCommandLine = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p>Show TaskCommandLineEvent messages.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters DisableShowCommandLine(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowCommandLine = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p>Show TaskCommandLineEvent messages.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ToggleShowCommandLine(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowCommandLine = !toolSettings.ShowCommandLine;
+            return toolSettings;
+        }
+        #endregion
+        #region ShowTimestamp
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p>Show the timestamp as a prefix to any message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters SetShowTimestamp(this MSBuildConsoleLoggerParameters toolSettings, bool? showTimestamp)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowTimestamp = showTimestamp;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p>Show the timestamp as a prefix to any message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ResetShowTimestamp(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowTimestamp = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p>Show the timestamp as a prefix to any message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters EnableShowTimestamp(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowTimestamp = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p>Show the timestamp as a prefix to any message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters DisableShowTimestamp(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowTimestamp = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p>Show the timestamp as a prefix to any message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ToggleShowTimestamp(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowTimestamp = !toolSettings.ShowTimestamp;
+            return toolSettings;
+        }
+        #endregion
+        #region ShowEventId
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.ShowEventId"/></em></p>
+        ///   <p>Show the event ID for each started event, finished event, and message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters SetShowEventId(this MSBuildConsoleLoggerParameters toolSettings, bool? showEventId)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowEventId = showEventId;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.ShowEventId"/></em></p>
+        ///   <p>Show the event ID for each started event, finished event, and message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ResetShowEventId(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowEventId = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.ShowEventId"/></em></p>
+        ///   <p>Show the event ID for each started event, finished event, and message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters EnableShowEventId(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowEventId = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.ShowEventId"/></em></p>
+        ///   <p>Show the event ID for each started event, finished event, and message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters DisableShowEventId(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowEventId = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.ShowEventId"/></em></p>
+        ///   <p>Show the event ID for each started event, finished event, and message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ToggleShowEventId(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowEventId = !toolSettings.ShowEventId;
+            return toolSettings;
+        }
+        #endregion
+        #region ForceNoAlign
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.ForceNoAlign"/></em></p>
+        ///   <p>Don't align the text to the size of the console buffer.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters SetForceNoAlign(this MSBuildConsoleLoggerParameters toolSettings, bool? forceNoAlign)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ForceNoAlign = forceNoAlign;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.ForceNoAlign"/></em></p>
+        ///   <p>Don't align the text to the size of the console buffer.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ResetForceNoAlign(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ForceNoAlign = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.ForceNoAlign"/></em></p>
+        ///   <p>Don't align the text to the size of the console buffer.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters EnableForceNoAlign(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ForceNoAlign = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.ForceNoAlign"/></em></p>
+        ///   <p>Don't align the text to the size of the console buffer.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters DisableForceNoAlign(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ForceNoAlign = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.ForceNoAlign"/></em></p>
+        ///   <p>Don't align the text to the size of the console buffer.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ToggleForceNoAlign(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ForceNoAlign = !toolSettings.ForceNoAlign;
+            return toolSettings;
+        }
+        #endregion
+        #region ConsoleColor
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.ConsoleColor"/></em></p>
+        ///   <p>If disabled, use the default console colors for all logging messages. (default is enabled)</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters SetConsoleColor(this MSBuildConsoleLoggerParameters toolSettings, bool? consoleColor)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ConsoleColor = consoleColor;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.ConsoleColor"/></em></p>
+        ///   <p>If disabled, use the default console colors for all logging messages. (default is enabled)</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ResetConsoleColor(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ConsoleColor = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.ConsoleColor"/></em></p>
+        ///   <p>If disabled, use the default console colors for all logging messages. (default is enabled)</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters EnableConsoleColor(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ConsoleColor = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.ConsoleColor"/></em></p>
+        ///   <p>If disabled, use the default console colors for all logging messages. (default is enabled)</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters DisableConsoleColor(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ConsoleColor = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.ConsoleColor"/></em></p>
+        ///   <p>If disabled, use the default console colors for all logging messages. (default is enabled)</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ToggleConsoleColor(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ConsoleColor = !toolSettings.ConsoleColor;
+            return toolSettings;
+        }
+        #endregion
+        #region MultiProcessorLogging
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters SetMultiProcessorLogging(this MSBuildConsoleLoggerParameters toolSettings, bool? multiProcessorLogging)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.MultiProcessorLogging = multiProcessorLogging;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ResetMultiProcessorLogging(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.MultiProcessorLogging = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildConsoleLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters EnableMultiProcessorLogging(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.MultiProcessorLogging = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildConsoleLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters DisableMultiProcessorLogging(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.MultiProcessorLogging = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildConsoleLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ToggleMultiProcessorLogging(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.MultiProcessorLogging = !toolSettings.MultiProcessorLogging;
+            return toolSettings;
+        }
+        #endregion
+        #region Verbosity
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildConsoleLoggerParameters.Verbosity"/></em></p>
+        ///   <p>Override the -verbosity setting for this logger.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters SetVerbosity(this MSBuildConsoleLoggerParameters toolSettings, MSBuildVerbosity verbosity)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Verbosity = verbosity;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildConsoleLoggerParameters.Verbosity"/></em></p>
+        ///   <p>Override the -verbosity setting for this logger.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildConsoleLoggerParameters ResetVerbosity(this MSBuildConsoleLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Verbosity = null;
+            return toolSettings;
+        }
+        #endregion
+    }
+    #endregion
+    #region MSBuildFileLoggerParametersExtensions
+    /// <summary>
+    ///   Used within <see cref="MSBuildTasks"/>.
+    /// </summary>
+    [PublicAPI]
+    [ExcludeFromCodeCoverage]
+    public static partial class MSBuildFileLoggerParametersExtensions
+    {
+        #region PerformanceSummary
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters SetPerformanceSummary(this MSBuildFileLoggerParameters toolSettings, bool? performanceSummary)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.PerformanceSummary = performanceSummary;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ResetPerformanceSummary(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.PerformanceSummary = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters EnablePerformanceSummary(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.PerformanceSummary = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters DisablePerformanceSummary(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.PerformanceSummary = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.PerformanceSummary"/></em></p>
+        ///   <p> Show the time that's spent in tasks, targets, and projects.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters TogglePerformanceSummary(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.PerformanceSummary = !toolSettings.PerformanceSummary;
+            return toolSettings;
+        }
+        #endregion
+        #region Summary
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.Summary"/></em></p>
+        ///   <p>Show the error and warning summary at the end.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters SetSummary(this MSBuildFileLoggerParameters toolSettings, bool? summary)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Summary = summary;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.Summary"/></em></p>
+        ///   <p>Show the error and warning summary at the end.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ResetSummary(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Summary = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.Summary"/></em></p>
+        ///   <p>Show the error and warning summary at the end.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters EnableSummary(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Summary = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.Summary"/></em></p>
+        ///   <p>Show the error and warning summary at the end.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters DisableSummary(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Summary = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.Summary"/></em></p>
+        ///   <p>Show the error and warning summary at the end.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ToggleSummary(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Summary = !toolSettings.Summary;
+            return toolSettings;
+        }
+        #endregion
+        #region ErrorsOnly
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p>Show only errors.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters SetErrorsOnly(this MSBuildFileLoggerParameters toolSettings, bool? errorsOnly)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ErrorsOnly = errorsOnly;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p>Show only errors.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ResetErrorsOnly(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ErrorsOnly = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p>Show only errors.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters EnableErrorsOnly(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ErrorsOnly = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p>Show only errors.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters DisableErrorsOnly(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ErrorsOnly = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.ErrorsOnly"/></em></p>
+        ///   <p>Show only errors.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ToggleErrorsOnly(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ErrorsOnly = !toolSettings.ErrorsOnly;
+            return toolSettings;
+        }
+        #endregion
+        #region WarningsOnly
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p>Show only warnings.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters SetWarningsOnly(this MSBuildFileLoggerParameters toolSettings, bool? warningsOnly)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.WarningsOnly = warningsOnly;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p>Show only warnings.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ResetWarningsOnly(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.WarningsOnly = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p>Show only warnings.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters EnableWarningsOnly(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.WarningsOnly = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p>Show only warnings.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters DisableWarningsOnly(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.WarningsOnly = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.WarningsOnly"/></em></p>
+        ///   <p>Show only warnings.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ToggleWarningsOnly(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.WarningsOnly = !toolSettings.WarningsOnly;
+            return toolSettings;
+        }
+        #endregion
+        #region NoItemAndPropertyList
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters SetNoItemAndPropertyList(this MSBuildFileLoggerParameters toolSettings, bool? noItemAndPropertyList)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.NoItemAndPropertyList = noItemAndPropertyList;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ResetNoItemAndPropertyList(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.NoItemAndPropertyList = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters EnableNoItemAndPropertyList(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.NoItemAndPropertyList = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters DisableNoItemAndPropertyList(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.NoItemAndPropertyList = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.NoItemAndPropertyList"/></em></p>
+        ///   <p>Don't show the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ToggleNoItemAndPropertyList(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.NoItemAndPropertyList = !toolSettings.NoItemAndPropertyList;
+            return toolSettings;
+        }
+        #endregion
+        #region ShowCommandLine
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p>Show TaskCommandLineEvent messages.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters SetShowCommandLine(this MSBuildFileLoggerParameters toolSettings, bool? showCommandLine)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowCommandLine = showCommandLine;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p>Show TaskCommandLineEvent messages.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ResetShowCommandLine(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowCommandLine = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p>Show TaskCommandLineEvent messages.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters EnableShowCommandLine(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowCommandLine = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p>Show TaskCommandLineEvent messages.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters DisableShowCommandLine(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowCommandLine = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.ShowCommandLine"/></em></p>
+        ///   <p>Show TaskCommandLineEvent messages.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ToggleShowCommandLine(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowCommandLine = !toolSettings.ShowCommandLine;
+            return toolSettings;
+        }
+        #endregion
+        #region ShowTimestamp
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p>Show the timestamp as a prefix to any message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters SetShowTimestamp(this MSBuildFileLoggerParameters toolSettings, bool? showTimestamp)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowTimestamp = showTimestamp;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p>Show the timestamp as a prefix to any message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ResetShowTimestamp(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowTimestamp = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p>Show the timestamp as a prefix to any message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters EnableShowTimestamp(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowTimestamp = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p>Show the timestamp as a prefix to any message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters DisableShowTimestamp(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowTimestamp = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.ShowTimestamp"/></em></p>
+        ///   <p>Show the timestamp as a prefix to any message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ToggleShowTimestamp(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowTimestamp = !toolSettings.ShowTimestamp;
+            return toolSettings;
+        }
+        #endregion
+        #region ShowEventId
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.ShowEventId"/></em></p>
+        ///   <p>Show the event ID for each started event, finished event, and message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters SetShowEventId(this MSBuildFileLoggerParameters toolSettings, bool? showEventId)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowEventId = showEventId;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.ShowEventId"/></em></p>
+        ///   <p>Show the event ID for each started event, finished event, and message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ResetShowEventId(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowEventId = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.ShowEventId"/></em></p>
+        ///   <p>Show the event ID for each started event, finished event, and message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters EnableShowEventId(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowEventId = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.ShowEventId"/></em></p>
+        ///   <p>Show the event ID for each started event, finished event, and message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters DisableShowEventId(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowEventId = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.ShowEventId"/></em></p>
+        ///   <p>Show the event ID for each started event, finished event, and message.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ToggleShowEventId(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ShowEventId = !toolSettings.ShowEventId;
+            return toolSettings;
+        }
+        #endregion
+        #region MultiProcessorLogging
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters SetMultiProcessorLogging(this MSBuildFileLoggerParameters toolSettings, bool? multiProcessorLogging)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.MultiProcessorLogging = multiProcessorLogging;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ResetMultiProcessorLogging(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.MultiProcessorLogging = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters EnableMultiProcessorLogging(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.MultiProcessorLogging = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters DisableMultiProcessorLogging(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.MultiProcessorLogging = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.MultiProcessorLogging"/></em></p>
+        ///   <p>Enable/Disable the multiprocessor logging style of output.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ToggleMultiProcessorLogging(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.MultiProcessorLogging = !toolSettings.MultiProcessorLogging;
+            return toolSettings;
+        }
+        #endregion
+        #region Verbosity
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.Verbosity"/></em></p>
+        ///   <p>Override the -verbosity setting for this logger.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters SetVerbosity(this MSBuildFileLoggerParameters toolSettings, MSBuildVerbosity verbosity)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Verbosity = verbosity;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.Verbosity"/></em></p>
+        ///   <p>Override the -verbosity setting for this logger.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ResetVerbosity(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Verbosity = null;
+            return toolSettings;
+        }
+        #endregion
+        #region LogFile
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.LogFile"/></em></p>
+        ///   <p>The path to the log file into which the build log is written. The distributed file logger prefixes this path to the names of its log files.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters SetLogFile(this MSBuildFileLoggerParameters toolSettings, string logFile)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.LogFile = logFile;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.LogFile"/></em></p>
+        ///   <p>The path to the log file into which the build log is written. The distributed file logger prefixes this path to the names of its log files.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ResetLogFile(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.LogFile = null;
+            return toolSettings;
+        }
+        #endregion
+        #region Append
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.Append"/></em></p>
+        ///   <p>Determines whether the build log is appended to the log file or overwrites it. When you set the switch, the build log is appended to the log file. When the switch is not present, the contents of an existing log file are overwritten.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters SetAppend(this MSBuildFileLoggerParameters toolSettings, bool? append)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Append = append;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.Append"/></em></p>
+        ///   <p>Determines whether the build log is appended to the log file or overwrites it. When you set the switch, the build log is appended to the log file. When the switch is not present, the contents of an existing log file are overwritten.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ResetAppend(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Append = null;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Enables <see cref="MSBuildFileLoggerParameters.Append"/></em></p>
+        ///   <p>Determines whether the build log is appended to the log file or overwrites it. When you set the switch, the build log is appended to the log file. When the switch is not present, the contents of an existing log file are overwritten.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters EnableAppend(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Append = true;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Disables <see cref="MSBuildFileLoggerParameters.Append"/></em></p>
+        ///   <p>Determines whether the build log is appended to the log file or overwrites it. When you set the switch, the build log is appended to the log file. When the switch is not present, the contents of an existing log file are overwritten.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters DisableAppend(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Append = false;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Toggles <see cref="MSBuildFileLoggerParameters.Append"/></em></p>
+        ///   <p>Determines whether the build log is appended to the log file or overwrites it. When you set the switch, the build log is appended to the log file. When the switch is not present, the contents of an existing log file are overwritten.</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ToggleAppend(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Append = !toolSettings.Append;
+            return toolSettings;
+        }
+        #endregion
+        #region Encoding
+        /// <summary>
+        ///   <p><em>Sets <see cref="MSBuildFileLoggerParameters.Encoding"/></em></p>
+        ///   <p>Specifies the encoding for the file (for example, UTF-8, Unicode, or ASCII).</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters SetEncoding(this MSBuildFileLoggerParameters toolSettings, string encoding)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Encoding = encoding;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="MSBuildFileLoggerParameters.Encoding"/></em></p>
+        ///   <p>Specifies the encoding for the file (for example, UTF-8, Unicode, or ASCII).</p>
+        /// </summary>
+        [Pure]
+        public static MSBuildFileLoggerParameters ResetEncoding(this MSBuildFileLoggerParameters toolSettings)
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Encoding = null;
             return toolSettings;
         }
         #endregion

--- a/source/Nuke.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -1,9 +1,11 @@
-// Copyright 2019 Maintainers of NUKE.
+﻿// Copyright 2019 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using JetBrains.Annotations;
 using Nuke.Common.Tooling;
 using Nuke.Common.Utilities;
@@ -43,6 +45,131 @@ namespace Nuke.Common.Tools.MSBuild
         private string GetToolPath()
         {
             return MSBuildToolPathResolver.Resolve(MSBuildVersion, MSBuildPlatform);
+        }
+
+
+        internal string GetFileLogger()
+        {
+            if (FileLogger == null)
+                return null;
+
+            var result = new StringBuilder();
+
+            // A maximum of 9 loggers are supported.
+            for (var i = 0; i < FileLogger.Count && i < 9; i++)
+            {
+                if (i != 0)
+                    result.Append(' ');
+
+                var fileLogger = FileLogger[i];
+                var builder = new MSBuildParameterBuilder($"/flp{i + 1}", true)
+                   .Add("PerformanceSummary", fileLogger.PerformanceSummary)
+                   .Add("Summary", "NoSummary", fileLogger.Summary)
+                   .Add("ErrorsOnly", fileLogger.ErrorsOnly)
+                   .Add("WarningsOnly", fileLogger.WarningsOnly)
+                   .Add("NoItemAndPropertyList", fileLogger.NoItemAndPropertyList)
+                   .Add("ShowCommandLine", fileLogger.ShowCommandLine)
+                   .Add("ShowTimestamp", fileLogger.ShowTimestamp)
+                   .Add("ShowEventId", fileLogger.ShowEventId)
+                   .Add("EnableMPLogging", "DisableMPLogging", fileLogger.MultiProcessorLogging)
+                   .Add("Verbosity", fileLogger.Verbosity?.ToString())
+                   .Add("LogFile", fileLogger.LogFile)
+                   .Add("Append", fileLogger.Append)
+                   .Add("Encoding", fileLogger.Encoding);
+
+                result.Append(builder.Render());
+            }
+
+            return result.ToString();
+        }
+
+        internal string GetConsoleLogger()
+        {
+            if (ConsoleLogger == null)
+                return null;
+
+            var builder = new MSBuildParameterBuilder("/consoleLoggerParameters", emptyParametersAllowed: false)
+               .Add("PerformanceSummary", ConsoleLogger.PerformanceSummary)
+               .Add("Summary", "NoSummary", ConsoleLogger.Summary)
+               .Add("ErrorsOnly", ConsoleLogger.ErrorsOnly)
+               .Add("WarningsOnly", ConsoleLogger.WarningsOnly)
+               .Add("NoItemAndPropertyList", ConsoleLogger.NoItemAndPropertyList)
+               .Add("ShowCommandLine", ConsoleLogger.ShowCommandLine)
+               .Add("ShowTimestamp", ConsoleLogger.ShowTimestamp)
+               .Add("ShowEventId", ConsoleLogger.ShowEventId)
+               .Add("ForceNoAlign", ConsoleLogger.ForceNoAlign)
+               .Add(null, "DisableConsoleColor", ConsoleLogger.ConsoleColor)
+               .Add("EnableMPLogging", "DisableMPLogging", ConsoleLogger.MultiProcessorLogging)
+               .Add("Verbosity", ConsoleLogger.Verbosity?.ToString());
+
+            return builder.Render();
+        }
+
+        private class MSBuildParameterBuilder
+        {
+            private List<(string Name, string Value)> _parameters = new List<(string Name, string Value)>();
+            private readonly bool _emptyParametersAllowed;
+
+            public MSBuildParameterBuilder(string argumentName, bool emptyParametersAllowed)
+            {
+                _emptyParametersAllowed = emptyParametersAllowed;
+                ArgumentName = argumentName;
+            }
+
+            public string ArgumentName { get; }
+
+            public MSBuildParameterBuilder Add(string name, bool? value)
+            {
+                if (value == true)
+                    _parameters.Add((name, null));
+
+                return this;
+            }
+
+            public MSBuildParameterBuilder Add(string nameIfTrue, string nameIfFalse, bool? value)
+            {
+                if (value == true && nameIfTrue != null)
+                    _parameters.Add((nameIfTrue, null));
+                else if (value == false && nameIfFalse != null)
+                    _parameters.Add((nameIfFalse, null));
+
+                return this;
+            }
+
+            public MSBuildParameterBuilder Add(string name, string value)
+            {
+                if (!string.IsNullOrEmpty(value))
+                    _parameters.Add((name, value));
+
+                return this;
+            }
+
+            public string Render()
+            {
+                if (!_emptyParametersAllowed && _parameters.Count == 0)
+                    return string.Empty;
+
+                var builder = new StringBuilder(ArgumentName);
+                if (_parameters.Count > 0)
+                {
+                    builder.Append(":\"");
+                    foreach (var kvp in _parameters)
+                    {
+                        builder.Append(kvp.Name);
+                        if (!string.IsNullOrEmpty(kvp.Value))
+                        {
+                            builder.Append('=');
+                            builder.Append(kvp.Value);
+                        }
+                        builder.Append(';');
+                    }
+
+                    // Remove trailing ';'
+                    builder.Length--;
+                    builder.Append('\"');
+                }
+                return builder.ToString();
+            }
         }
     }
 }

--- a/source/Nuke.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -48,20 +48,20 @@ namespace Nuke.Common.Tools.MSBuild
         }
 
 
-        internal string GetFileLogger()
+        internal string GetFileLoggers()
         {
-            if (FileLogger == null)
+            if (FileLoggers == null)
                 return null;
 
             var result = new StringBuilder();
 
             // A maximum of 9 loggers are supported.
-            for (var i = 0; i < FileLogger.Count && i < 9; i++)
+            for (var i = 0; i < FileLoggers.Count && i < 9; i++)
             {
                 if (i != 0)
                     result.Append(' ');
 
-                var fileLogger = FileLogger[i];
+                var fileLogger = FileLoggers[i];
                 var builder = new MSBuildParameterBuilder($"/flp{i + 1}", true)
                    .Add("PerformanceSummary", fileLogger.PerformanceSummary)
                    .Add("Summary", "NoSummary", fileLogger.Summary)

--- a/source/Nuke.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright 2019 Maintainers of NUKE.
+﻿// Copyright 2019 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -29,6 +29,24 @@ namespace Nuke.Common.Tools.MSBuild
             return toolSettings
                 .AddLoggers($"JetBrains.BuildServer.MSBuildLoggers.MSBuildLogger,{teamCityLogger}")
                 .EnableNoConsoleLogger();
+        }
+
+        public static MSBuildSettings AddFileLogger(this MSBuildSettings toolSettings, params Func<MSBuildFileLoggerParameters, MSBuildFileLoggerParameters>[] configurators)
+        {
+            var instance = new MSBuildFileLoggerParameters();
+            return toolSettings.AddFileLogger(configurators.Select(configurator => configurator(instance)));
+        }
+
+        public static MSBuildSettings SetFileLogger(this MSBuildSettings toolSettings, params Func<MSBuildFileLoggerParameters, MSBuildFileLoggerParameters>[] configurators)
+        {
+            var instance = new MSBuildFileLoggerParameters();
+            return toolSettings.SetFileLogger(configurators.Select(configurator => configurator(instance)));
+        }
+
+        public static MSBuildSettings SetConsoleLogger(this MSBuildSettings toolSettings, Func<MSBuildConsoleLoggerParameters, MSBuildConsoleLoggerParameters> configurator)
+        {
+            var instance = new MSBuildConsoleLoggerParameters();
+            return toolSettings.SetConsoleLogger(configurator(instance));
         }
     }
 }

--- a/source/Nuke.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -31,21 +31,21 @@ namespace Nuke.Common.Tools.MSBuild
                 .EnableNoConsoleLogger();
         }
 
-        public static MSBuildSettings AddFileLogger(this MSBuildSettings toolSettings, params Func<MSBuildFileLoggerParameters, MSBuildFileLoggerParameters>[] configurators)
+        public static MSBuildSettings AddFileLogger(this MSBuildSettings toolSettings, params Func<MSBuildFileLogger, MSBuildFileLogger>[] configurators)
         {
-            var instance = new MSBuildFileLoggerParameters();
-            return toolSettings.AddFileLogger(configurators.Select(configurator => configurator(instance)));
+            var instance = new MSBuildFileLogger();
+            return toolSettings.AddFileLoggers(configurators.Select(configurator => configurator(instance)));
         }
 
-        public static MSBuildSettings SetFileLogger(this MSBuildSettings toolSettings, params Func<MSBuildFileLoggerParameters, MSBuildFileLoggerParameters>[] configurators)
+        public static MSBuildSettings SetFileLogger(this MSBuildSettings toolSettings, params Func<MSBuildFileLogger, MSBuildFileLogger>[] configurators)
         {
-            var instance = new MSBuildFileLoggerParameters();
-            return toolSettings.SetFileLogger(configurators.Select(configurator => configurator(instance)));
+            var instance = new MSBuildFileLogger();
+            return toolSettings.SetFileLoggers(configurators.Select(configurator => configurator(instance)));
         }
 
-        public static MSBuildSettings SetConsoleLogger(this MSBuildSettings toolSettings, Func<MSBuildConsoleLoggerParameters, MSBuildConsoleLoggerParameters> configurator)
+        public static MSBuildSettings SetConsoleLogger(this MSBuildSettings toolSettings, Func<MSBuildConsoleLogger, MSBuildConsoleLogger> configurator)
         {
-            var instance = new MSBuildConsoleLoggerParameters();
+            var instance = new MSBuildConsoleLogger();
             return toolSettings.SetConsoleLogger(configurator(instance));
         }
     }


### PR DESCRIPTION
Added ConsoleLogger and FileLogger to MSBuildSettings, allowing fluent API specification of parameters for file loggers and the console logger when running MSBuild.

Example:
```
            MSBuild(s => s
                .SetTargetPath(Solution)
                .SetTargets("Rebuild")
                .SetConfiguration(Configuration)
                .AddFileLogger(l => l
                     .SetLogFile("D:\\mylog.log")
                     .DisableAppend()
                     .SetVerbosity(MSBuildVerbosity.Normal)
                     .EnableShowTimestamp()
                     .EnablePerformanceSummary()
                )
                .SetMaxCpuCount(Environment.ProcessorCount)
                .SetNodeReuse(IsLocalBuild));
```

Fixes nuke-build/nuke#314
