### PR TITLE
Make ExecutableTarget Metadata available to consuming libraries

### DIFF
--- a/source/Nuke.Common/CI/ArtifactExtensions.cs
+++ b/source/Nuke.Common/CI/ArtifactExtensions.cs
@@ -59,5 +59,25 @@ namespace Nuke.Common.CI
             Partitions.Add(targetDefinition, (member.Name, member.GetCustomAttribute<PartitionAttribute>().Total));
             return targetDefinition;
         }
+
+        public static (string partitionName, int totalPartitions) GetPartition(ExecutableTarget target)
+        {
+            return Partitions.GetValueOrDefault(target.Definition);
+        }
+
+        public static IEnumerable<string> GetArtifactProducts(ExecutableTarget target)
+        {
+            return ArtifactProducts[target.Definition] ?? Array.Empty<string>();
+        }
+
+        public static IEnumerable<(Target target, string[] artifacts)> GetArtifactDependencies(ExecutableTarget target)
+        {
+            return ArtifactDependencies[target.Definition] ?? Array.Empty<(Target target, string[] artifacts)>();
+        }
+
+        public static string GetPartitionDashedName(string partitionName)
+        {
+            return ParameterService.GetParameterDashedName(partitionName);
+        }
     }
 }

--- a/source/Nuke.Common/Execution/ExecutableTarget.cs
+++ b/source/Nuke.Common/Execution/ExecutableTarget.cs
@@ -18,25 +18,25 @@ namespace Nuke.Common.Execution
         {
         }
 
-        internal MemberInfo Member { get; set; }
+        public MemberInfo Member { get; internal set; }
         internal TargetDefinition Definition { get; set; }
         public string Name { get; internal set; }
         public string Description { get; internal set; }
         public bool Listed { get; internal set; }
-        internal Target Factory { get; set; }
-        internal ICollection<Expression<Func<bool>>> DynamicConditions { get; set; } = new List<Expression<Func<bool>>>();
-        internal ICollection<Expression<Func<bool>>> StaticConditions { get; set; } = new List<Expression<Func<bool>>>();
-        internal DependencyBehavior DependencyBehavior { get; set; }
-        internal bool AssuredAfterFailure { get; set; }
-        internal bool ProceedAfterFailure { get; set; }
-        internal ICollection<LambdaExpression> Requirements { get; set; } = new List<LambdaExpression>();
-        internal ICollection<Action> Actions { get; set; } = new List<Action>();
-        internal ICollection<ExecutableTarget> ExecutionDependencies { get; } = new List<ExecutableTarget>();
-        internal ICollection<ExecutableTarget> OrderDependencies { get; } = new List<ExecutableTarget>();
-        internal ICollection<ExecutableTarget> TriggerDependencies { get; } = new List<ExecutableTarget>();
-        internal ICollection<ExecutableTarget> Triggers { get; } = new List<ExecutableTarget>();
+        public Target Factory { get; internal set; }
+        public ICollection<Expression<Func<bool>>> DynamicConditions { get; internal set; } = new List<Expression<Func<bool>>>();
+        public ICollection<Expression<Func<bool>>> StaticConditions { get; internal set; } = new List<Expression<Func<bool>>>();
+        public DependencyBehavior DependencyBehavior { get; internal set; }
+        public bool AssuredAfterFailure { get; internal set; }
+        public bool ProceedAfterFailure { get; internal set; }
+        public ICollection<LambdaExpression> Requirements { get; internal set; } = new List<LambdaExpression>();
+        public ICollection<Action> Actions { get; internal set; } = new List<Action>();
+        public ICollection<ExecutableTarget> ExecutionDependencies { get; } = new List<ExecutableTarget>();
+        public ICollection<ExecutableTarget> OrderDependencies { get; } = new List<ExecutableTarget>();
+        public ICollection<ExecutableTarget> TriggerDependencies { get; } = new List<ExecutableTarget>();
+        public ICollection<ExecutableTarget> Triggers { get; } = new List<ExecutableTarget>();
 
-        internal IReadOnlyCollection<ExecutableTarget> AllDependencies
+        public IReadOnlyCollection<ExecutableTarget> AllDependencies
             => ExecutionDependencies.Concat(OrderDependencies).Concat(TriggerDependencies).ToList();
 
         public bool IsDefault { get; internal set; }

--- a/source/Nuke.Common/Execution/ExecutionPlanner.cs
+++ b/source/Nuke.Common/Execution/ExecutionPlanner.cs
@@ -15,7 +15,7 @@ namespace Nuke.Common.Execution
     /// <summary>
     /// Given the invoked target names, creates an execution plan under consideration of execution, ordering and trigger dependencies.
     /// </summary>
-    internal static class ExecutionPlanner
+    public static class ExecutionPlanner
     {
         public static IReadOnlyCollection<ExecutableTarget> GetExecutionPlan(
             IReadOnlyCollection<ExecutableTarget> executableTargets,


### PR DESCRIPTION
As we had discussed earlier this an adjustment to my old PR.

* Made all properties on `ExecutableTarget` public, but with internal settings where appropriate
* Made `ExecutionPlanner` public
* Added methods to `ArtifactExtensions` to fetch data from internal dictionary and lookups by target (not definition)