### PR TITLE
Correct the msbuild tools property key lookup

### DIFF
--- a/source/Nuke.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -25,7 +25,7 @@ namespace Nuke.Common.Tools.MSBuild
         public static MSBuildSettings AddTeamCityLogger(this MSBuildSettings toolSettings)
         {
             var teamCity = TeamCity.Instance.NotNull("TeamCity.Instance != null");
-            var teamCityLogger = teamCity.ConfigurationProperties["TEAMCITY_DOTNET_MSBUILD_EXTENSIONS4_0"];
+            var teamCityLogger = teamCity.ConfigurationProperties["teamcity.dotnet.msbuild.extensions4.0"];
             return toolSettings
                 .AddLoggers($"JetBrains.BuildServer.MSBuildLoggers.MSBuildLogger,{teamCityLogger}")
                 .EnableNoConsoleLogger();


### PR DESCRIPTION
The property keys changed format int he latest nuke, but this extension is still looking for the key in the old format

<!--

RULES FOR PULL-REQUESTS:

- Start from `develop` (or `master` if not available)
- Use `rebase` over `merge`
- Don't mind if the destination branch was force-pushed

-->
