### PR TITLE
Change default DotCover NuGet package to jetbrains.dotcover.dotnetcli…

### DIFF
--- a/build/specifications/DotCover.json
+++ b/build/specifications/DotCover.json
@@ -6,8 +6,7 @@
   "name": "DotCover",
   "officialUrl": "https://www.jetbrains.com/dotcover",
   "help": "dotCover is a .NET unit testing and code coverage tool that works right in Visual Studio, helps you know to what extent your code is covered with unit tests, provides great ways to visualize code coverage, and is Continuous Integration ready. dotCover calculates and reports statement-level code coverage in applications targeting .NET Framework, Silverlight, and .NET Core.",
-  "packageId": "JetBrains.dotCover.CommandLineTools",
-  "packageExecutable": "dotCover.exe",
+  "customExecutable": true,
   "tasks": [
     {
       "postfix": "Analyse",

--- a/source/Nuke.Common/Tools/DotCover/DotCover.Generated.cs
+++ b/source/Nuke.Common/Tools/DotCover/DotCover.Generated.cs
@@ -31,7 +31,7 @@ namespace Nuke.Common.Tools.DotCover
         /// </summary>
         public static string DotCoverPath =>
             ToolPathResolver.TryGetEnvironmentExecutable("DOTCOVER_EXE") ??
-            ToolPathResolver.GetPackageExecutable("JetBrains.dotCover.CommandLineTools", "dotCover.exe");
+            GetToolPath();
         public static Action<OutputType, string> DotCoverLogger { get; set; } = ProcessTasks.DefaultLogger;
         /// <summary>
         ///   <p>dotCover is a .NET unit testing and code coverage tool that works right in Visual Studio, helps you know to what extent your code is covered with unit tests, provides great ways to visualize code coverage, and is Continuous Integration ready. dotCover calculates and reports statement-level code coverage in applications targeting .NET Framework, Silverlight, and .NET Core.</p>
@@ -470,7 +470,7 @@ namespace Nuke.Common.Tools.DotCover
         /// <summary>
         ///   Path to the DotCover executable.
         /// </summary>
-        public override string ToolPath => base.ToolPath ?? DotCoverTasks.DotCoverPath;
+        public override string ToolPath => base.ToolPath ?? GetToolPath();
         public override Action<OutputType, string> CustomLogger => DotCoverTasks.DotCoverLogger;
         public virtual string Configuration { get; internal set; }
         /// <summary>
@@ -589,7 +589,7 @@ namespace Nuke.Common.Tools.DotCover
         /// <summary>
         ///   Path to the DotCover executable.
         /// </summary>
-        public override string ToolPath => base.ToolPath ?? DotCoverTasks.DotCoverPath;
+        public override string ToolPath => base.ToolPath ?? GetToolPath();
         public override Action<OutputType, string> CustomLogger => DotCoverTasks.DotCoverLogger;
         public virtual string Configuration { get; internal set; }
         /// <summary>
@@ -698,7 +698,7 @@ namespace Nuke.Common.Tools.DotCover
         /// <summary>
         ///   Path to the DotCover executable.
         /// </summary>
-        public override string ToolPath => base.ToolPath ?? DotCoverTasks.DotCoverPath;
+        public override string ToolPath => base.ToolPath ?? GetToolPath();
         public override Action<OutputType, string> CustomLogger => DotCoverTasks.DotCoverLogger;
         public virtual string Configuration { get; internal set; }
         /// <summary>
@@ -733,7 +733,7 @@ namespace Nuke.Common.Tools.DotCover
         /// <summary>
         ///   Path to the DotCover executable.
         /// </summary>
-        public override string ToolPath => base.ToolPath ?? DotCoverTasks.DotCoverPath;
+        public override string ToolPath => base.ToolPath ?? GetToolPath();
         public override Action<OutputType, string> CustomLogger => DotCoverTasks.DotCoverLogger;
         public virtual string Configuration { get; internal set; }
         /// <summary>
@@ -778,7 +778,7 @@ namespace Nuke.Common.Tools.DotCover
         /// <summary>
         ///   Path to the DotCover executable.
         /// </summary>
-        public override string ToolPath => base.ToolPath ?? DotCoverTasks.DotCoverPath;
+        public override string ToolPath => base.ToolPath ?? GetToolPath();
         public override Action<OutputType, string> CustomLogger => DotCoverTasks.DotCoverLogger;
         public virtual string Configuration { get; internal set; }
         /// <summary>
@@ -828,7 +828,7 @@ namespace Nuke.Common.Tools.DotCover
         /// <summary>
         ///   Path to the DotCover executable.
         /// </summary>
-        public override string ToolPath => base.ToolPath ?? DotCoverTasks.DotCoverPath;
+        public override string ToolPath => base.ToolPath ?? GetToolPath();
         public override Action<OutputType, string> CustomLogger => DotCoverTasks.DotCoverLogger;
         public virtual string Configuration { get; internal set; }
         /// <summary>

--- a/source/Nuke.Common/Tools/DotCover/DotCoverTasks.cs
+++ b/source/Nuke.Common/Tools/DotCover/DotCoverTasks.cs
@@ -1,0 +1,62 @@
+﻿using Nuke.Common.Tooling;
+
+namespace Nuke.Common.Tools.DotCover
+{
+    public static partial class DotCoverTasks
+    {
+        internal static string GetToolPath()
+        {
+            return ToolPathResolver.GetPackageExecutable(
+                "jetbrains.dotcover.dotnetclitool|JetBrains.dotCover.CommandLineTools",
+                EnvironmentInfo.IsWin ? "dotCover.exe" : "dotCover.sh|dotCover.exe");
+        }
+    }
+
+    public partial class DotCoverMergeSettings
+    {
+        private string GetToolPath()
+        {
+            return DotCoverTasks.GetToolPath();
+        }
+    }
+
+    public partial class DotCoverAnalyseSettings
+    {
+        private string GetToolPath()
+        {
+            return DotCoverTasks.GetToolPath();
+        }
+    }
+
+    public partial class DotCoverCoverSettings
+    {
+        private string GetToolPath()
+        {
+            return DotCoverTasks.GetToolPath();
+        }
+    }
+
+    public partial class DotCoverDeleteSettings
+    {
+        private string GetToolPath()
+        {
+            return DotCoverTasks.GetToolPath();
+        }
+    }
+
+    public partial class DotCoverReportSettings
+    {
+        private string GetToolPath()
+        {
+            return DotCoverTasks.GetToolPath();
+        }
+    }
+
+    public partial class DotCoverZipSettings
+    {
+        private string GetToolPath()
+        {
+            return DotCoverTasks.GetToolPath();
+        }
+    }
+}


### PR DESCRIPTION
…tool

This allows to run DotCover on Linux without mono

Hereby, I swear that the pull-request:

- [X] Follows the [contribution guidelines](CONTRIBUTING.md)
- [X] Contains my own work
- [X] Is in compliance with my employer